### PR TITLE
Add 'inDialog' and 'onOpenCallback' props to Select components

### DIFF
--- a/src/atoms/hooks/useSelect.ts
+++ b/src/atoms/hooks/useSelect.ts
@@ -21,7 +21,8 @@ import { groupBy } from 'lodash';
 const useSelect = <T extends SelectOptionRequired>(
   props: SelectComponentProps<T>
 ) => {
-  const { loading, disabled, sortValues, onSearchChange } = props;
+  const { loading, disabled, sortValues, onSearchChange, onOpenCallback } =
+    props;
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
   const searchRef = useRef<HTMLInputElement | null>(null);
@@ -64,6 +65,12 @@ const useSelect = <T extends SelectOptionRequired>(
       return firstIndex - secondIndex;
     });
   }, [props, sortValues]);
+
+  useEffect(() => {
+    if (onOpenCallback !== undefined) {
+      onOpenCallback(open);
+    }
+  }, [onOpenCallback, open]);
 
   useEffect(() => {
     if (

--- a/src/molecules/Select/ComboBox/ComboBox.stories.tsx
+++ b/src/molecules/Select/ComboBox/ComboBox.stories.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { Button, Dialog } from '@equinor/eds-core-react';
 import { faker } from '@faker-js/faker';
 import { actions } from '@storybook/addon-actions';
 import { StoryFn } from '@storybook/react';
@@ -136,5 +137,48 @@ export const ComboBoxParented: StoryFn = (args) => {
       values={values}
       onSelect={handleOnSelect}
     />
+  );
+};
+
+export const ComboBoxInDialog: StoryFn = (args) => {
+  const [openDialog, setOpenDialog] = useState(false);
+  const [values, setValues] = useState<SelectOption<Item>[]>([]);
+  const [openComboBox, setOpenComboBox] = useState(false);
+
+  const handleOnSelect = (
+    selectedValues: SelectOption<Item>[],
+    selectedValue?: SelectOption<Item>
+  ) => {
+    actions('onSelect').onSelect(selectedValues, selectedValue);
+    setValues(selectedValues);
+  };
+
+  const handleOnComboboxOpen = (value: boolean) => setOpenComboBox(value);
+
+  const handleDialogOnClose = () => {
+    if (!openComboBox) setOpenDialog(false);
+  };
+
+  return (
+    <>
+      <Button onClick={() => setOpenDialog(true)}>Open dialog</Button>
+      <Dialog
+        open={openDialog}
+        onClose={handleDialogOnClose}
+        isDismissable
+        style={{ width: '40rem ' }}
+      >
+        <Dialog.Content>
+          <ComboBox
+            {...args}
+            inDialog
+            onOpenCallback={handleOnComboboxOpen}
+            items={FAKE_ITEMS}
+            values={values}
+            onSelect={handleOnSelect}
+          />
+        </Dialog.Content>
+      </Dialog>
+    </>
   );
 };

--- a/src/molecules/Select/Select.styles.ts
+++ b/src/molecules/Select/Select.styles.ts
@@ -159,7 +159,7 @@ interface CustomMenuItemProps {
 }
 
 const StyledMenuItem = styled(EDSMenu.Item)<CustomMenuItemProps>`
-  flex: 1;
+  flex-grow: 1;
   border-radius: 2px;
   ${({ $paddedLeft }) => $paddedLeft && `margin-left: 36px`};
   padding-left: 10px;

--- a/src/molecules/Select/Select.test.tsx
+++ b/src/molecules/Select/Select.test.tsx
@@ -1099,3 +1099,75 @@ test('onSearchChange to be called with value when typing in input field', async 
   await user.type(searchField, 'Test');
   expect(handleOnSearchChange).toHaveBeenCalledWith('Test');
 });
+
+test('inDialog works as expected', async () => {
+  const handler = vi.fn();
+  const items = fakeSelectItems();
+  const placeholder = faker.airline.airplane().name;
+  const outside = faker.vehicle.vehicle();
+
+  render(
+    <>
+      <Select
+        placeholder={placeholder}
+        inDialog
+        onSelect={handler}
+        items={items}
+        value={undefined}
+      />
+      <p>{outside}</p>
+    </>
+  );
+  const user = userEvent.setup();
+
+  await user.click(screen.getByText(placeholder));
+
+  for (const item of items) {
+    expect(screen.getByText(item.label)).toBeInTheDocument();
+  }
+
+  await user.click(screen.getByText(outside));
+
+  for (const item of items) {
+    expect(screen.queryByText(item.label)).not.toBeInTheDocument();
+  }
+});
+
+test('openCallback works as expected', async () => {
+  const handler = vi.fn();
+  const items = fakeSelectItems();
+  const placeholder = faker.airline.airplane().name;
+  const outside = faker.vehicle.vehicle();
+  const openCallback = vi.fn();
+
+  render(
+    <>
+      <Select
+        placeholder={placeholder}
+        inDialog
+        onSelect={handler}
+        items={items}
+        value={undefined}
+        onOpenCallback={openCallback}
+      />
+      <p>{outside}</p>
+    </>
+  );
+  const user = userEvent.setup();
+
+  // Open
+  await user.click(screen.getByText(placeholder));
+
+  expect(openCallback).toHaveBeenCalledWith(true);
+
+  // Close
+  await user.click(screen.getByText(placeholder));
+
+  expect(openCallback).toHaveBeenCalledWith(false);
+
+  // Open and click outside
+  await user.click(screen.getByText(placeholder));
+  await user.click(screen.getByText(outside));
+
+  expect(openCallback).toHaveBeenCalledWith(false);
+});

--- a/src/molecules/Select/Select.tsx
+++ b/src/molecules/Select/Select.tsx
@@ -3,6 +3,7 @@ import { useMemo, useRef } from 'react';
 import { CircularProgress, Icon, Label } from '@equinor/eds-core-react';
 import { arrow_drop_down, arrow_drop_up, clear } from '@equinor/eds-icons';
 import { tokens } from '@equinor/eds-tokens';
+import { useOutsideClick } from '@equinor/eds-utils';
 
 import { useSelect } from 'src/atoms/hooks/useSelect';
 import { GroupedSelectMenu } from 'src/molecules/Select/GroupedSelectMenu';
@@ -47,6 +48,7 @@ export const Select = <T extends SelectOptionRequired>(
     meta,
     id = `amplify-combobox-${label}`,
     variant,
+    inDialog = false,
   } = props;
   const {
     handleOnClear,
@@ -75,9 +77,26 @@ export const Select = <T extends SelectOptionRequired>(
     placeholder,
   });
   const anchorRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
   const shouldShowTopMargin = useMemo(() => {
     return !!label || !!meta;
   }, [label, meta]);
+
+  useOutsideClick(menuRef.current, (event) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    if (
+      inDialog &&
+      open &&
+      event.target &&
+      anchorRef.current &&
+      menuRef.current &&
+      !anchorRef.current.contains(event.target as Node) &&
+      !menuRef.current?.contains(event.target as Node)
+    ) {
+      handleOnClose();
+    }
+  });
 
   const valueElements = useMemo(() => {
     if ('value' in props && props.value) {
@@ -158,6 +177,7 @@ export const Select = <T extends SelectOptionRequired>(
       </Container>
       {open && (
         <StyledMenu
+          ref={menuRef}
           open
           id="combobox-menu"
           anchorEl={anchorRef.current}

--- a/src/molecules/Select/Select.tsx
+++ b/src/molecules/Select/Select.tsx
@@ -83,8 +83,6 @@ export const Select = <T extends SelectOptionRequired>(
   }, [label, meta]);
 
   useOutsideClick(menuRef.current, (event) => {
-    event.preventDefault();
-    event.stopImmediatePropagation();
     if (
       inDialog &&
       open &&

--- a/src/molecules/Select/Select.types.ts
+++ b/src/molecules/Select/Select.types.ts
@@ -85,4 +85,6 @@ export interface CommonSelectProps {
   clearable?: boolean;
   meta?: string;
   onSearchChange?: (inputValue: string) => void;
+  inDialog?: boolean;
+  onOpenCallback?: (value: boolean) => void;
 }


### PR DESCRIPTION
Currently the onclose of the combobox/singlselect does not work when you click outside the menu (specifically just to the right of the menu) when it is placed inside a dialog 🫠 

This PR adds 2 news props which can be used to get the desired onclose behaviour when using select components inside an EDS dialog