### PR TITLE
Fix error in parsing value for 'border'

### DIFF
--- a/src/organisms/TopBar/TopBar.styles.ts
+++ b/src/organisms/TopBar/TopBar.styles.ts
@@ -119,7 +119,7 @@ export const TopBarButton = styled(Button)<ButtonProps>`
   height: ${({ $fieldSelector }) => ($fieldSelector ? '' : '36px')};
   width: ${({ $fieldSelector }) => ($fieldSelector ? '' : '36px')};
   border: ${({ $isSelected }) =>
-    $isSelected ? `1px solid #132E31` : '1px solid none'};
+    $isSelected ? `1px solid #132E31` : '1px solid transparent'};
   color: ${({ $isSelected }) =>
     $isSelected ? '#132E31' : colors.interactive.primary__resting.rgba};
   &:hover ${UnreadRedDot} {


### PR DESCRIPTION
Fixes an error in parsing the value for the 'border' property. Previously, the code was setting the border to '1px solid none' instead of '1px solid transparent' when the element was not selected.

Error:

```
Error in parsing value for ‘border’.  Declaration dropped. 5339:6:13108
Elements matching selector: .kFmpSZ
NodeList [ button.Button__ButtonBase-sc-1hs0myn-1.ihpSAG.sc-SrAaV.kFmpSZ ]
​
0: <button class="Button__ButtonBase-sc-1h… ihpSAG sc-SrAaV kFmpSZ" type="button" tabindex="0" data-testid="field-selector-top-bar-button">
​
length: 1
​
<prototype>: NodeListPrototype { item: item(), keys: keys(), values: values(), … }
```
