### PR TITLE
fix: moves label out of flex wrapper to remove extra gap causing missalignment with other input fields

### DIFF
--- a/src/molecules/Select/Select.tsx
+++ b/src/molecules/Select/Select.tsx
@@ -150,8 +150,8 @@ export const Select = <T extends SelectOptionRequired>(
 
   return (
     <div>
+      {shouldShowLabel && <Label label={label} meta={meta} htmlFor={id} />}
       <Wrapper>
-        {shouldShowLabel && <Label label={label} meta={meta} htmlFor={id} />}
         <Container
           data-testid="combobox-container"
           ref={anchorRef}


### PR DESCRIPTION
This pull request fixes a styling issue. The `Select` component label has been put into flex wrapper making the gap between the label and input field bigger. This casues misaligment issue with other fields like `TextField`.

![image](https://github.com/user-attachments/assets/6c271231-ba8a-4c14-9f9e-040d45c33561)
