### PR TITLE
:adhesive_bandage: Add withHover prop to app icon in topbar

### DIFF
--- a/src/organisms/TopBar/TopBar.tsx
+++ b/src/organisms/TopBar/TopBar.tsx
@@ -49,7 +49,7 @@ export const TopBar = forwardRef<HTMLDivElement, TopBarType>(
       <Bar ref={ref}>
         <AppAndFieldContainer>
           <AppIdentifier onClick={onHeaderClick} tabIndex={0}>
-            <ApplicationIcon name={applicationIcon} size={32} />
+            <ApplicationIcon name={applicationIcon} size={32} withHover />
             <AppName
               group="navigation"
               variant="menu_title"


### PR DESCRIPTION
Just adding back withHover prop to appIcon in topbar, so it works "as before" 