### PR TITLE
fix: update secret scanning workflow to use only verified

### DIFF
--- a/.github/workflows/secret_scanning.yaml
+++ b/.github/workflows/secret_scanning.yaml
@@ -15,4 +15,4 @@ jobs:
           path: ./
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
-          extra_args: --debug --no-verification
+          extra_args: --only-verified

--- a/config/config_files/workflows/secret_scanning.yaml
+++ b/config/config_files/workflows/secret_scanning.yaml
@@ -15,4 +15,4 @@ jobs:
           path: ./
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
-          extra_args: --debug --no-verification
+          extra_args: --only-verified


### PR DESCRIPTION
## Description

Previously the `secret_scanning.yaml` uses the arguments `debug` and `no-verification` which was more like a testing.

Setting up `--only-verified` which should be more stable as will look for only output verified results.