### PR TITLE
:bug: Fix 'Read more' in long release notes

### DIFF
--- a/src/organisms/TopBar/Resources/ReleaseNotesDialog/ReleasePosts/ReleasePost/ReleasePost.tsx
+++ b/src/organisms/TopBar/Resources/ReleaseNotesDialog/ReleasePosts/ReleasePost/ReleasePost.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, useRef, useState } from 'react';
 
 import { Icon, Typography } from '@equinor/eds-core-react';
 import { arrow_drop_down, arrow_drop_up } from '@equinor/eds-icons';
@@ -32,13 +32,18 @@ export const ReleasePost: FC<ReleaseNote> = ({
 }) => {
   const [showFullContent, setShowFullContent] = useState<boolean>(false);
   const [needsShowMoreButton, setNeedsShowMoreButton] = useState(false);
-
-  // TODO: Could not get the test to work properly (get the height from the element), created a task for it (BUG 438384 in Azure board)
   /* c8 ignore start */
+  const resizeObserver = useRef<ResizeObserver>(
+    new ResizeObserver((entries) => {
+      // Since we only ever observer 1 element we can safely access [0]
+      const { height } = entries[0].contentRect;
+      setNeedsShowMoreButton(height > 108);
+    })
+  );
+
   const handleOnNewRef = (element: HTMLDivElement | null) => {
     if (element) {
-      const { clientHeight } = element;
-      setNeedsShowMoreButton(clientHeight > 108);
+      resizeObserver.current.observe(element);
     }
   };
   /* c8 ignore end */

--- a/src/tests/mockHandlers.ts
+++ b/src/tests/mockHandlers.ts
@@ -18,7 +18,7 @@ export const fakeReleaseNotes: ReleaseNote[] = [
     applicationName: 'PWEX',
     version: null,
     title: 'Improved task board and reporting overview June',
-    body: '<h1>Release notes body text</h1>',
+    body: '<h1>Release notes body text</h1><br/><br/><br/><p>Hei</p>',
     tags: [ReleaseNoteType.FEATURE, ReleaseNoteType.IMPROVEMENT],
     createdDate: faker.date.past().toDateString(),
   },


### PR DESCRIPTION
Bug:
- [AB#540813](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/540813)