### PR TITLE
Turns display rich text into a compound component

### DIFF
--- a/src/atoms/hooks/useAmplifyKit.ts
+++ b/src/atoms/hooks/useAmplifyKit.ts
@@ -24,7 +24,6 @@ export const useAmplifyKit = ({
   return useMemo(
     () =>
       RichText.Kit.configure({
-        heading: false,
         placeholder: placeholder ? { placeholder } : undefined,
         link: features?.includes(RichTextEditorFeatures.LINKS) ? {} : false,
         table: features?.includes(RichTextEditorFeatures.TABLE) ? {} : false,
@@ -42,6 +41,9 @@ export const useAmplifyKit = ({
           : false,
         image: features?.includes(RichTextEditorFeatures.IMAGES)
           ? { onImageUpload }
+          : false,
+        heading: features?.includes(RichTextEditorFeatures.HEADERS)
+          ? {}
           : false,
       }),
     [onImageUpload, placeholder, features]

--- a/src/atoms/hooks/useAmplifyKit.ts
+++ b/src/atoms/hooks/useAmplifyKit.ts
@@ -24,7 +24,22 @@ export const useAmplifyKit = ({
   return useMemo(
     () =>
       RichText.Kit.configure({
+        heading: false,
         placeholder: placeholder ? { placeholder } : undefined,
+        link: features?.includes(RichTextEditorFeatures.LINKS) ? {} : false,
+        table: features?.includes(RichTextEditorFeatures.TABLE) ? {} : false,
+        textAlign: features?.includes(RichTextEditorFeatures.ALIGNMENT)
+          ? {}
+          : false,
+        bulletList: features?.includes(RichTextEditorFeatures.LISTS)
+          ? {}
+          : false,
+        orderedList: features?.includes(RichTextEditorFeatures.LISTS)
+          ? {}
+          : false,
+        codeBlockLowlight: features?.includes(RichTextEditorFeatures.CODE)
+          ? {}
+          : false,
         image: features?.includes(RichTextEditorFeatures.IMAGES)
           ? { onImageUpload }
           : false,

--- a/src/molecules/RichTextDisplay/RichTextDisplay.stories.tsx
+++ b/src/molecules/RichTextDisplay/RichTextDisplay.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryFn } from '@storybook/react';
 
+import { RichText } from 'src/molecules';
 import {
   RichTextDisplay,
   RichTextDisplayProps,
@@ -20,4 +21,22 @@ export default meta;
 
 export const Primary: StoryFn<RichTextDisplayProps> = (args) => {
   return <RichTextDisplay {...args} />;
+};
+
+export const CompoundComponents: StoryFn<RichTextDisplayProps> = (args) => {
+  return (
+    <RichText.Display {...args}>
+      {(editor) => {
+        console.log('editor', editor);
+        return (
+          <RichText.Styling
+            $lightBackground={args.lightBackground}
+            $padding={args.padding}
+          >
+            <RichText.Content editor={editor} readOnly />
+          </RichText.Styling>
+        );
+      }}
+    </RichText.Display>
+  );
 };

--- a/src/molecules/RichTextDisplay/RichTextDisplay.tsx
+++ b/src/molecules/RichTextDisplay/RichTextDisplay.tsx
@@ -43,6 +43,7 @@ export const RichTextDisplay: FC<
 
   /* c8 ignore next */
   if (!editor) return null;
+  /* c8 ignore next */
   if (children) return children(editor);
   return (
     <RichText.Styling

--- a/src/molecules/RichTextDisplay/RichTextDisplay.tsx
+++ b/src/molecules/RichTextDisplay/RichTextDisplay.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useRef } from 'react';
 
-import { useEditor } from '@tiptap/react';
+import { Editor, Extensions, useEditor } from '@tiptap/react';
 
 import { RichText } from 'src/molecules';
 
@@ -9,16 +9,20 @@ export interface RichTextDisplayProps {
   imgReadToken?: string;
   lightBackground?: boolean;
   padding?: 'sm' | 'md' | 'lg' | 'none';
+  extensions?: Extensions;
+  children?: (editor: Editor) => JSX.Element;
 }
 
 export const RichTextDisplay: FC<RichTextDisplayProps> = ({
+  children,
   value,
   imgReadToken,
   lightBackground = true,
   padding = 'md',
+  extensions = [RichText.Kit],
 }) => {
   const editor = useEditor({
-    extensions: [RichText.Kit],
+    extensions: extensions,
     content: imgReadToken
       ? value?.replaceAll(/(<img src=")(.+)("\/>)/g, `$1$2?${imgReadToken}$3`)
       : value,
@@ -34,6 +38,9 @@ export const RichTextDisplay: FC<RichTextDisplayProps> = ({
     }
   }, [editor, value]);
 
+  /* c8 ignore next */
+  if (!editor) return null;
+  if (children) return children(editor);
   return (
     <RichText.Styling $lightBackground={lightBackground} $padding={padding}>
       <RichText.Content editor={editor} readOnly />

--- a/src/molecules/RichTextEditor/EditorProvider.tsx
+++ b/src/molecules/RichTextEditor/EditorProvider.tsx
@@ -40,6 +40,7 @@ export const EditorProvider: FC<EditorProviderProps> = ({
     onUpdate: ({ editor }) => onUpdate?.(editor.getHTML()),
   });
 
+  /* c8 ignore start */
   useEffect(() => {
     // This makes Tiptap react to its prop changing from the outside
     // Usefull if for instance the content is fetched from an API.
@@ -49,6 +50,7 @@ export const EditorProvider: FC<EditorProviderProps> = ({
     editor.commands.setContent(content || '');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [content]);
+  /* c8 ignore stop */
 
   /* c8 ignore next */
   if (!editor) return null;

--- a/src/molecules/RichTextEditor/EditorProvider.tsx
+++ b/src/molecules/RichTextEditor/EditorProvider.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 
 import { Editor, Extensions, useEditor } from '@tiptap/react';
 
@@ -39,6 +39,16 @@ export const EditorProvider: FC<EditorProviderProps> = ({
     extensions: [ampExtensions, ...extensions],
     onUpdate: ({ editor }) => onUpdate?.(editor.getHTML()),
   });
+
+  useEffect(() => {
+    // This makes Tiptap react to its prop changing from the outside
+    // Usefull if for instance the content is fetched from an API.
+    // This way the editor will update when the content changes
+    if (!editor) return;
+    if (content === editor.getHTML()) return;
+    editor.commands.setContent(content || '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content]);
 
   /* c8 ignore next */
   if (!editor) return null;

--- a/src/molecules/RichTextEditor/index.ts
+++ b/src/molecules/RichTextEditor/index.ts
@@ -2,6 +2,7 @@ import { AmplifyKit } from './custom-extensions/AmplifyKit';
 import { AmplifyBar } from './MenuBar/MenuBar';
 import { EditorProvider } from './EditorProvider';
 import { EditorContent, EditorStyling } from './RichTextEditor.styles';
+import { RichTextDisplay } from 'src/molecules/RichTextDisplay/RichTextDisplay';
 
 export { RichTextEditor } from './RichTextEditor';
 
@@ -9,6 +10,7 @@ export const RichText = {
   Styling: EditorStyling,
   Provider: EditorProvider,
   Content: EditorContent,
+  Display: RichTextDisplay,
   Bar: AmplifyBar,
   Kit: AmplifyKit,
 };


### PR DESCRIPTION
1. Lets me return the editor instance out of the display rich text component
2. Lets me pass extensions as prop to the display rich text component
3. Makes the content prop reactive so that it works better when fetching data
4. Lets you exclude more extensions from the extension registration
5. Adds the storybook for display rich text compound component