### PR TITLE
:children_crossing: Make InfoElement props less strict to allow setting copyable/capitalize dynamically

### DIFF
--- a/src/molecules/InfoElement/InfoElement.test.tsx
+++ b/src/molecules/InfoElement/InfoElement.test.tsx
@@ -62,3 +62,25 @@ test('Capitalizing content works as expected', () => {
 
   expect(screen.getByText(expectedContentString)).toBeInTheDocument();
 });
+
+test('Copyable / capitalize content and ReactElement throws error', () => {
+  console.error = vi.fn();
+  expect(() =>
+    render(
+      <InfoElement
+        title="TestTitle"
+        content={<Button>Click me!</Button>}
+        copyableContent
+      />
+    )
+  ).toThrowError();
+  expect(() =>
+    render(
+      <InfoElement
+        title="TestTitle"
+        content={<Button>Click me!</Button>}
+        capitalizeContent
+      />
+    )
+  ).toThrowError();
+});

--- a/src/molecules/InfoElement/InfoElement.tsx
+++ b/src/molecules/InfoElement/InfoElement.tsx
@@ -5,50 +5,47 @@ import CopyText from 'src/molecules/InfoElement/CopyText';
 
 export interface InfoElementProps {
   title: string;
+  content: string | ReactElement;
+  capitalizeContent?: boolean;
+  copyableContent?: boolean;
 }
 
 /**
- * @param content - Text
- * @param copyableContent - Should the content be copyable via hover - Defaults to false
- * @param capitalizeContent - Should the content be capitalized - Defaults to false
+ * @param title - String
+ * @param content - String | ReactElement
+ * @param copyableContent - Should the content be copyable via hover - Defaults to false (only works when content is string)
+ * @param capitalizeContent - Should the content be capitalized - Defaults to false (only works when content is string)
  */
-interface TextInfoElementProps extends InfoElementProps {
-  content: string;
-  copyableContent?: boolean;
-  capitalizeContent?: boolean;
-}
+export const InfoElement = forwardRef<HTMLDivElement, InfoElementProps>(
+  ({ title, content, copyableContent, capitalizeContent }, ref) => {
+    if (typeof content !== 'string' && (copyableContent || capitalizeContent)) {
+      throw new Error(
+        'copyableContent and capitalizeContent only works when content is string'
+      );
+    }
 
-interface CustomInfoElementProps extends InfoElementProps {
-  content: ReactElement;
-  copyableContent?: false;
-  capitalizeContent?: false;
-}
-
-export const InfoElement = forwardRef<
-  HTMLDivElement,
-  TextInfoElementProps | CustomInfoElementProps
->(({ title, content, copyableContent, capitalizeContent }, ref) => {
-  const contentElement =
-    typeof content === 'string' ? (
-      <Typography variant="h6">
-        {capitalizeContent ? content.toUpperCase() : content}
-      </Typography>
-    ) : (
-      content
-    );
-
-  return (
-    <div ref={ref}>
-      <Typography group="paragraph" variant="overline">
-        {title?.toUpperCase()}
-      </Typography>
-      {copyableContent ? (
-        <CopyText textToCopy={content}>{contentElement}</CopyText>
+    const contentElement =
+      typeof content === 'string' ? (
+        <Typography variant="h6">
+          {capitalizeContent ? content.toUpperCase() : content}
+        </Typography>
       ) : (
-        contentElement
-      )}
-    </div>
-  );
-});
+        content
+      );
+
+    return (
+      <div ref={ref}>
+        <Typography group="paragraph" variant="overline">
+          {title?.toUpperCase()}
+        </Typography>
+        {copyableContent && typeof content === 'string' ? (
+          <CopyText textToCopy={content}>{contentElement}</CopyText>
+        ) : (
+          contentElement
+        )}
+      </div>
+    );
+  }
+);
 
 InfoElement.displayName = 'InfoElement';


### PR DESCRIPTION
- [AB#531491](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/531491)