### PR TITLE
:sparkles: Lets child components trigger the onClose handler in the notifications topbar

### DIFF
--- a/src/organisms/TopBar/Notifications/Notifications.stories.tsx
+++ b/src/organisms/TopBar/Notifications/Notifications.stories.tsx
@@ -13,6 +13,7 @@ import {
 } from './NotificationsTemplate/Notifications.types';
 import { Notifications } from './Notifications';
 import { NotificationsProps } from './NotificationsInner';
+import { Button } from '@equinor/eds-core-react';
 
 export default {
   title: 'Organisms/TopBar/Notifications',
@@ -147,5 +148,22 @@ export const Primary: StoryFn<NotificationsProps> = (args) => {
       showFilterOptions={true}
       notifications={items}
     />
+  );
+};
+
+export const RenderProps: StoryFn<NotificationsProps> = (args) => {
+  return (
+    <Notifications
+      hasUnread={args.hasUnread}
+      setAllAsRead={() => null}
+      showFilterOptions={true}
+      notifications={items}
+    >
+      {({ onClose }) => (
+        <Button onClick={onClose} variant="outlined">
+          Discard all
+        </Button>
+      )}
+    </Notifications>
   );
 };

--- a/src/organisms/TopBar/Notifications/Notifications.stories.tsx
+++ b/src/organisms/TopBar/Notifications/Notifications.stories.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@equinor/eds-core-react';
 import { Meta, StoryFn } from '@storybook/react';
 
 import {
@@ -13,7 +14,6 @@ import {
 } from './NotificationsTemplate/Notifications.types';
 import { Notifications } from './Notifications';
 import { NotificationsProps } from './NotificationsInner';
-import { Button } from '@equinor/eds-core-react';
 
 export default {
   title: 'Organisms/TopBar/Notifications',

--- a/src/organisms/TopBar/Notifications/Notifications.test.tsx
+++ b/src/organisms/TopBar/Notifications/Notifications.test.tsx
@@ -238,6 +238,31 @@ test('Calls setAllAsRead when pressing outside of panel', async () => {
   expect(screen.queryByTestId('top-bar-menu')).not.toBeInTheDocument();
 });
 
+test('Calls setAllAsRead when triggering handler outside the component', async () => {
+  const randomText = faker.animal.dog();
+  const setAllAsRead = vi.fn();
+  render(
+    <Notifications setAllAsRead={setAllAsRead}>
+      {({ onClose }) => <button onClick={onClose}>{randomText}</button>}
+    </Notifications>
+  );
+  const user = userEvent.setup();
+
+  const buttons = screen.getAllByRole('button');
+
+  const closeButton = buttons[0];
+
+  await user.click(closeButton);
+
+  expect(screen.getByTestId('top-bar-menu')).toBeVisible();
+
+  const butttonInsidePanel = screen.getByText(randomText);
+
+  await user.click(butttonInsidePanel);
+
+  expect(screen.queryByTestId('top-bar-menu')).not.toBeInTheDocument();
+});
+
 test('Renders unread dot when unread = true', async () => {
   render(
     <Notifications setAllAsRead={() => null} hasUnread {...notificationsData} />

--- a/src/organisms/TopBar/Notifications/NotificationsInner.tsx
+++ b/src/organisms/TopBar/Notifications/NotificationsInner.tsx
@@ -39,7 +39,7 @@ export interface NotificationsProps {
   setAllAsRead: () => void;
   hasUnread?: boolean;
   showFilterOptions?: boolean;
-  children?: ReactNode;
+  children?: ReactNode | (({ onClose }: { onClose: () => void }) => ReactNode);
   notifications?: (
     | ReadyToReportNotificationTypes
     | RequestChangeOrcaTypes
@@ -147,7 +147,9 @@ export const NotificationsInner: FC<NotificationsProps> = ({
         )}
 
         {children ? (
-          <Content>{children}</Content>
+          <Content>
+            {children instanceof Function ? children({ onClose }) : children}
+          </Content>
         ) : (
           <Content>
             {filteredAndSortedNotifications &&


### PR DESCRIPTION
I need to be able to close the notifications dropdown programatically in PWEX. This gives us the option to access the onClose handler inside the notifications component