### PR TITLE
fix: deny access to env.sh

### DIFF
--- a/config/config_files/nginx.conf
+++ b/config/config_files/nginx.conf
@@ -17,11 +17,15 @@ server {
     }
 
     location /env-config.js {
-      add_header Cache-Control "no-cache";
-      proxy_cache_bypass $http_pragma;
+        add_header Cache-Control "no-cache";
+        proxy_cache_bypass $http_pragma;
         proxy_cache_revalidate on;
         expires off;
         access_log off;
+    }
+
+    location /env.sh {
+        deny all;
     }
 
     location ~ \.html$ {


### PR DESCRIPTION
## Description

This PR addresses the issue of exposing the env.sh file across all applications. The current setup makes this script accessible, but nginx is properly configured to prevent code execution or any exploit agains the file.

> [!NOTE]
> Although  The file/content do not appear to be immediately exploitable, exposing this file might not be a best practice as it reveal some server configuration.

**_A more secure/better solution would be to remove the file from the publicly accessible directory entirely._**

Maybe we should move the env.sh outside the webserver’s public directory and modify the docker image to run the script on start container from a different directory.