### PR TITLE
:wrench: Fix for acl and common dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN chown -R nginx /etc/nginx/conf.d \
     && chmod +x ./secrets.sh
 
 # Add bash shell
-RUN apk update && apk add --no-cache bash~=5.2.26
+RUN apk update && apk add --no-cache bash~=5.2.37
 
 USER 101
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,9 +30,6 @@ RUN chown -R nginx /etc/nginx/conf.d \
     && chown -R nginx /usr/share/nginx/html \
     && chmod +x ./secrets.sh
 
-# Add bash shell
-RUN apk update && apk add --no-cache bash~=5.2.37
-
 USER 101
 
 CMD ["/bin/bash", "-c", "./secrets.sh && nginx -g \"daemon off;\""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ RUN chown -R nginx /etc/nginx/conf.d \
 
 USER 101
 
-CMD ["/bin/bash", "-c", "./secrets.sh && nginx -g \"daemon off;\""]
+CMD ["/bin/sh", "-c", "./secrets.sh && nginx -g \"daemon off;\""]

--- a/config/config_files/Dockerfile
+++ b/config/config_files/Dockerfile
@@ -40,4 +40,6 @@ RUN rm -rf ./env-config.js \
   && chmod +x ./env.sh
 
 # Add bash shell
+USER 101
+
 CMD ["/bin/sh", "-c", "./env.sh && nginx -g \"daemon off;\""]

--- a/config/config_files/Dockerfile
+++ b/config/config_files/Dockerfile
@@ -40,7 +40,7 @@ RUN rm -rf ./env-config.js \
   && chmod +x ./env.sh
 
 # Add bash shell
-RUN apk update && apk add --no-cache bash~=5.2.26
+RUN apk update && apk add --no-cache bash~=5.2.37
 USER 101
 
 CMD ["/bin/bash", "-c", "./env.sh && nginx -g \"daemon off;\""]

--- a/config/config_files/env.sh
+++ b/config/config_files/env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Add assignment
 echo "window._env_ = {" >>./env-config.js

--- a/secrets.sh
+++ b/secrets.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 envsubst '$GITHUB_PAT_SEARCH_TOKEN' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
Premo, dasha, js embark (probably all) all failed to build docker image, and couldnt deploy to radix. 
This version bump seems to fix it.