### PR TITLE
:children_crossing: Make SideBar menu items top container scrollable

### DIFF
--- a/src/organisms/SideBar/CreateItem.styles.ts
+++ b/src/organisms/SideBar/CreateItem.styles.ts
@@ -13,6 +13,7 @@ export const MenuItemContainer = styled.div<MenuItemContainerProps>`
   display: flex;
   align-self: stretch;
   align-items: center;
+  min-height: 64px;
   height: 64px;
   padding: 0 14px;
   border-bottom: 1px solid ${colors.ui.background__medium.rgba};

--- a/src/organisms/SideBar/MenuItem.styles.ts
+++ b/src/organisms/SideBar/MenuItem.styles.ts
@@ -21,6 +21,7 @@ export const Link = styled(ReactRouterDomLink)<LinkProps>`
   align-items: center;
   justify-content: ${({ $open }) => !$open && 'center'};
   height: 64px;
+  min-width: 64px;
   padding: ${spacings.medium};
   gap: ${spacings.medium};
   box-sizing: border-box;

--- a/src/organisms/SideBar/SideBar.styles.ts
+++ b/src/organisms/SideBar/SideBar.styles.ts
@@ -32,6 +32,8 @@ export const TopItemContainer = styled.div`
   align-items: flex-start;
   flex: 1 0 0;
   align-self: stretch;
+  overflow-y: auto;
+  overflow-x: hidden;
 `;
 
 export const BottomItemContainer = styled.div`


### PR DESCRIPTION
[AB#585148](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/585148)