### PR TITLE
Fix/export-component-full-render

### DIFF
--- a/src/atoms/utils/export.ts
+++ b/src/atoms/utils/export.ts
@@ -36,10 +36,15 @@ export const exportComponent = (
   }
 
   const element = node.current;
+  const scrollWidth = element.scrollWidth;
+  const scrollHeight = element.scrollHeight;
+
   return html2canvas(element, {
     scrollY: -window.scrollY,
     useCORS: true,
     backgroundColor: backgroundColor ? backgroundColor : '#FFFFFF',
+    width: scrollWidth,
+    height: scrollHeight,
   }).then((canvas) => {
     return dataURItoBlob(canvas.toDataURL('image/png', 1.0));
   });

--- a/src/atoms/utils/export.ts
+++ b/src/atoms/utils/export.ts
@@ -36,8 +36,12 @@ export const exportComponent = (
   }
 
   const element = node.current;
+
   const scrollWidth = element.scrollWidth;
   const scrollHeight = element.scrollHeight;
+
+  element.setAttribute('style', 'box-shadow: none');
+  element.setAttribute('style', 'overflow: visible');
 
   return html2canvas(element, {
     scrollY: -window.scrollY,
@@ -46,6 +50,7 @@ export const exportComponent = (
     width: scrollWidth,
     height: scrollHeight,
   }).then((canvas) => {
+    element.removeAttribute('style');
     return dataURItoBlob(canvas.toDataURL('image/png', 1.0));
   });
 };


### PR DESCRIPTION
Before, if an element had a scrollbar, the hidden content wasn’t included in the exported image. This change ensures the whole element gets exported.