### PR TITLE
Feat/add-disabled-state-to-stepper-steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-component-lib",
-  "version": "9.9.2",
+  "version": "9.9.3",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-component-lib",
-  "version": "9.9.3",
+  "version": "9.10.0",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/molecules/Stepper/Step/Step.tsx
+++ b/src/molecules/Stepper/Step/Step.tsx
@@ -72,6 +72,8 @@ export const Step: FC<StepProps> = ({
       $clickable={index < currentStep}
       onClick={handleOnClick}
       $disabled={isDisabled}
+      aria-disabled={isDisabled}
+      role="button"
     >
       <StepIcon index={index} disabled={isDisabled} />
       {(!onlyShowCurrentStepLabel || currentStep === index) && (

--- a/src/molecules/Stepper/Step/Step.tsx
+++ b/src/molecules/Stepper/Step/Step.tsx
@@ -11,6 +11,7 @@ import styled, { css } from 'styled-components';
 
 interface ContainerProps {
   $clickable: boolean;
+  $disabled?: boolean;
 }
 
 const Container = styled.div<ContainerProps>`
@@ -18,13 +19,19 @@ const Container = styled.div<ContainerProps>`
   gap: ${spacings.small};
   align-items: center;
   white-space: nowrap;
-  ${(props) =>
-    props.$clickable &&
-    css`
-      &:hover {
-        cursor: pointer;
-      }
-    `}
+  ${({ $disabled, $clickable }) =>
+    $disabled
+      ? css`
+          &:hover {
+            cursor: not-allowed;
+          }
+        `
+      : $clickable &&
+        css`
+          &:hover {
+            cursor: pointer;
+          }
+        `}
 `;
 
 interface StepProps {
@@ -38,7 +45,9 @@ export const Step: FC<StepProps> = ({
   onlyShowCurrentStepLabel = false,
   children,
 }) => {
-  const { currentStep, setCurrentStep } = useStepper();
+  const { currentStep, setCurrentStep, isStepAtIndexDisabled } = useStepper();
+
+  const isDisabled = isStepAtIndexDisabled(index);
 
   const textVariant = useMemo((): TypographyVariants => {
     if (index < currentStep) return 'body_short';
@@ -46,12 +55,13 @@ export const Step: FC<StepProps> = ({
   }, [currentStep, index]);
 
   const textColor = useMemo((): string | undefined => {
-    if (index > currentStep) return colors.interactive.disabled__text.rgba;
+    if (index > currentStep || isDisabled)
+      return colors.interactive.disabled__text.rgba;
     return colors.text.static_icons__default.rgba;
-  }, [currentStep, index]);
+  }, [currentStep, index, isDisabled]);
 
   const handleOnClick = () => {
-    if (index < currentStep) {
+    if (index < currentStep && !isDisabled) {
       setCurrentStep(index);
     }
   };
@@ -61,8 +71,9 @@ export const Step: FC<StepProps> = ({
       data-testid="step"
       $clickable={index < currentStep}
       onClick={handleOnClick}
+      $disabled={isDisabled}
     >
-      <StepIcon index={index} />
+      <StepIcon index={index} disabled={isDisabled} />
       {(!onlyShowCurrentStepLabel || currentStep === index) && (
         <Typography variant={textVariant} color={textColor}>
           {children}

--- a/src/molecules/Stepper/Step/StepIcon.tsx
+++ b/src/molecules/Stepper/Step/StepIcon.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 
 import { Icon, Typography } from '@equinor/eds-core-react';
-import { check } from '@equinor/eds-icons';
+import { check, lock } from '@equinor/eds-icons';
 
 import { colors, shape } from 'src/atoms/style';
 import { useStepper } from 'src/providers/StepperProvider';
@@ -42,10 +42,15 @@ const IconWrapper = styled.span<IconWrapperProps>`
 
 interface StepIconProps {
   index: number;
+  disabled?: boolean;
 }
 
-export const StepIcon: FC<StepIconProps> = ({ index }) => {
+export const StepIcon: FC<StepIconProps> = ({ index, disabled }) => {
   const { currentStep } = useStepper();
+
+  if (disabled) {
+    return <Icon data={lock} color={colors.interactive.disabled__text.rgba} />;
+  }
 
   if (index >= currentStep) {
     return (

--- a/src/molecules/Stepper/Stepper.stories.tsx
+++ b/src/molecules/Stepper/Stepper.stories.tsx
@@ -31,6 +31,7 @@ const meta: Meta<typeof Stepper> = {
   },
   decorators: (Story, { parameters }) => {
     const syncToURL = parameters?.syncToURL ?? false;
+    const disabledSteps = parameters?.disabledSteps ?? false;
     return (
       <RouterProvider
         router={createMemoryRouter(
@@ -66,6 +67,7 @@ const meta: Meta<typeof Stepper> = {
                       label: 'Finish order',
                     },
                   ]}
+                  isStepDisabled={disabledSteps ? isStepDisabled : undefined}
                 >
                   <Story />
                 </StepperProvider>
@@ -120,7 +122,13 @@ export const Primary: StoryFn<StepperProps> = (args) => {
 };
 
 const Story = (args: StepperProps) => {
-  const { steps, goToNextStep, goToPreviousStep, currentStep } = useStepper();
+  const {
+    steps,
+    goToNextStep,
+    goToPreviousStep,
+    currentStep,
+    isStepAtIndexDisabled,
+  } = useStepper();
   const { pathname } = useLocation();
 
   return (
@@ -131,7 +139,7 @@ const Story = (args: StepperProps) => {
         <Button
           variant="outlined"
           onClick={goToPreviousStep}
-          disabled={currentStep === 0}
+          disabled={isStepAtIndexDisabled(currentStep - 1)}
         >
           Previous
         </Button>
@@ -149,6 +157,24 @@ const Story = (args: StepperProps) => {
 export const SyncedToURL: StoryObj = {
   parameters: {
     syncToURL: true,
+  },
+  render: () => <Story />,
+};
+
+const isStepDisabled = ({
+  stepIndex,
+  currentStepIndex,
+}: {
+  stepIndex: number;
+  currentStepIndex: number;
+}) => {
+  return stepIndex < currentStepIndex;
+};
+
+export const DisabledSteps: StoryObj = {
+  parameters: {
+    syncToURL: true,
+    disabledSteps: true,
   },
   render: () => <Story />,
 };

--- a/src/molecules/Stepper/Stepper.stories.tsx
+++ b/src/molecules/Stepper/Stepper.stories.tsx
@@ -161,15 +161,15 @@ export const SyncedToURL: StoryObj = {
   render: () => <Story />,
 };
 
-const isStepDisabled = ({
+function isStepDisabled({
   stepIndex,
   currentStepIndex,
 }: {
   stepIndex: number;
   currentStepIndex: number;
-}) => {
+}) {
   return stepIndex < currentStepIndex;
-};
+}
 
 export const DisabledSteps: StoryObj = {
   parameters: {

--- a/src/molecules/Stepper/Stepper.test.tsx
+++ b/src/molecules/Stepper/Stepper.test.tsx
@@ -310,3 +310,39 @@ test('Works as expected with sync to url', async () => {
 
   expect(screen.getByText(`Current location: /create/1`)).toBeInTheDocument();
 });
+
+function isStepDisabled({ stepIndex }: { stepIndex: number }) {
+  return stepIndex === 0;
+}
+
+test('Disabled steps work as expected', async () => {
+  const steps = fakeSteps();
+
+  render(<StepperTestComponent />, {
+    wrapper: ({ children }) => (
+      <RouterProvider
+        router={createMemoryRouter(
+          [
+            {
+              path: '/create/:step',
+              element: (
+                <StepperProvider
+                  steps={steps}
+                  syncToURLParam
+                  isStepDisabled={isStepDisabled}
+                >
+                  {children}
+                </StepperProvider>
+              ),
+            },
+          ],
+          { initialEntries: ['/create/2'] }
+        )}
+      />
+    ),
+  });
+
+  const firstStep = screen.getByText(steps[0].label);
+  expect(firstStep).toBeInTheDocument();
+  expect(firstStep).toBeDisabled();
+});

--- a/src/providers/StepperProvider.tsx
+++ b/src/providers/StepperProvider.tsx
@@ -1,4 +1,11 @@
-import { createContext, FC, ReactNode, useContext, useState } from 'react';
+import {
+  createContext,
+  FC,
+  ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 
 interface SubStep {
@@ -6,17 +13,17 @@ interface SubStep {
   description?: string;
 }
 
-interface StepWithSubSteps {
-  label: string;
-  title?: undefined;
-  description?: undefined;
-  subSteps: [SubStep, SubStep, ...SubStep[]];
-}
-
-interface StepWithoutSubSteps {
+interface CommonStep {
   label: string;
   title?: string;
   description?: string;
+}
+
+interface StepWithSubSteps extends CommonStep {
+  subSteps: [SubStep, SubStep, ...SubStep[]];
+}
+
+interface StepWithoutSubSteps extends CommonStep {
   subSteps?: undefined;
 }
 
@@ -29,6 +36,7 @@ interface StepperContextType {
   setCurrentStep: (value: number) => void;
   goToNextStep: () => void;
   goToPreviousStep: () => void;
+  isStepAtIndexDisabled: (stepIndex: number) => boolean;
 }
 
 export const StepperContext = createContext<StepperContextType | undefined>(
@@ -46,6 +54,17 @@ export function useStepper() {
 export interface StepperProviderProps {
   steps: [Step, Step, ...Step[]];
   children: ReactNode;
+  isStepDisabled?: ({
+    step,
+    stepIndex,
+    currentStep,
+    currentStepIndex,
+  }: {
+    step: Step;
+    stepIndex: number;
+    currentStep: Step;
+    currentStepIndex: number;
+  }) => boolean;
 }
 
 interface StepperProviderSyncedToURLParamProps extends StepperProviderProps {
@@ -66,7 +85,7 @@ interface StepperProviderWithoutSyncToURLParamProps
 export const StepperProvider: FC<
   | StepperProviderSyncedToURLParamProps
   | StepperProviderWithoutSyncToURLParamProps
-> = ({ steps, children, ...rest }) => {
+> = ({ steps, children, isStepDisabled, ...rest }) => {
   const { step } = useParams();
   const navigate = useNavigate();
   const pathWithoutStep = useLocation()
@@ -141,6 +160,21 @@ export const StepperProvider: FC<
     }
   };
 
+  const checkIfStepIsDisabled: StepperContextType['isStepAtIndexDisabled'] =
+    useCallback(
+      (stepIndex) => {
+        if (isStepDisabled)
+          return isStepDisabled({
+            step: steps[stepIndex],
+            stepIndex,
+            currentStep: steps[usingStep],
+            currentStepIndex: usingStep,
+          });
+        return false;
+      },
+      [isStepDisabled, usingStep, steps]
+    );
+
   return (
     <StepperContext.Provider
       value={{
@@ -150,6 +184,7 @@ export const StepperProvider: FC<
         setCurrentStep: handleOnSetStep,
         goToNextStep,
         goToPreviousStep,
+        isStepAtIndexDisabled: checkIfStepIsDisabled,
       }}
     >
       {children}


### PR DESCRIPTION
Adds an `isStepDisabled` callback prop to the `StepperProvider`, allowing you to specify whether a particular step should be disabled.

### Not disabled
![Molecules  Stepper - Synced To URL ⋅ Storybook 2025-05-07 at 12 25 09](https://github.com/user-attachments/assets/0574fdd5-fc25-47ee-b365-6f573a087f75)


### Disabled
![Molecules  Stepper - Disabled Steps ⋅ Storybook 2025-05-07 at 12 25 00](https://github.com/user-attachments/assets/f9ded351-8187-4df5-b2ae-b177cfba26bb)