### PR TITLE
:bug: Add missing --eds_table__* css text color variables

### DIFF
--- a/src/atoms/style/darkTokens.ts
+++ b/src/atoms/style/darkTokens.ts
@@ -204,5 +204,14 @@ export const darkTokens = css`
     --eds_interactive__icon_on_interactive_colors: rgba(255, 255, 255, 1);
 
     --eds_ui__chip__badge_color: var(--eds_text_static_icons__default);
+
+    /* Override table typography variables */
+    --eds_table__cell_header_color: var(--eds_text__static_icons__default);
+    --eds_table__cell_text_color: var(--eds_text__static_icons__default);
+    --eds_table__cell_text_bold_color: var(--eds_text__static_icons__default);
+    --eds_table__cell_text_link_color: var(--eds_text__static_icons__default);
+    --eds_table__cell_numeric_monospaced_color: var(
+      --eds_text__static_icons__default
+    );
   }
 `;

--- a/src/atoms/style/lightTokens.ts
+++ b/src/atoms/style/lightTokens.ts
@@ -144,5 +144,14 @@ export const lightTokens = css`
     --eds_interactive__link_in_snackbars: rgba(151, 202, 206, 1);
     --eds_interactive__pressed_overlay_dark: rgba(0, 0, 0, 0.2);
     --eds_interactive__pressed_overlay_light: rgba(255, 255, 255, 0.2);
+
+    /* Override table typography variables */
+    --eds_table__cell_header_color: var(--eds_text__static_icons__default);
+    --eds_table__cell_text_color: var(--eds_text__static_icons__default);
+    --eds_table__cell_text_bold_color: var(--eds_text__static_icons__default);
+    --eds_table__cell_text_link_color: var(--eds_text__static_icons__default);
+    --eds_table__cell_numeric_monospaced_color: var(
+      --eds_text__static_icons__default
+    );
   }
 `;


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#635132](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/635132)

---

- [ ] Needs to be tested locally by reviewer

# Description

- This PR adds missing text colors css variables for the typography table cell variants


