### PR TITLE
:bug: Fix 'isBetweenDates' not working with string

### DIFF
--- a/src/atoms/utils/date.test.ts
+++ b/src/atoms/utils/date.test.ts
@@ -454,6 +454,16 @@ test('isBetweenDates works as expected with todays date between itself', () => {
   const formatted = isBetweenDates(today, [today, today]);
   expect(formatted).toEqual(true);
 });
+
+test('isBetweenDates works as expected with string date', () => {
+  const today = new Date();
+  const yesterday = new Date(new Date().setDate(new Date().getDate() - 1));
+  const tomorrow = new Date(new Date().setDate(new Date().getDate() + 1));
+
+  const formatted = isBetweenDates(formatDate(today), [yesterday, tomorrow]);
+  expect(formatted).toEqual(true);
+});
+
 describe('UTC timestamps', () => {
   const utcDate = '2021-06-30T22:00:00+00:00';
   test('should accept UTC timestamps and get that date back in UTC in the format of DD. month YYYY', () => {

--- a/src/atoms/utils/date.ts
+++ b/src/atoms/utils/date.ts
@@ -160,7 +160,7 @@ export const isBetweenDates = (
   if (date) {
     const dateObj = new Date(date);
     if (dateObj.getTime()) {
-      return date >= dates[0] && date <= dates[1];
+      return dateObj >= dates[0] && dateObj <= dates[1];
     }
   }
   return false;

--- a/src/molecules/RichTextEditor/MenuBar/TextColor.test.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextColor.test.tsx
@@ -8,6 +8,7 @@ import {
   renderWithProviders,
   screen,
   userEvent,
+  waitFor,
 } from 'src/tests/browsertest-utils';
 
 function fakeProps(): RichTextEditorProps {
@@ -34,8 +35,12 @@ test('Able to change color', async () => {
   (input as HTMLInputElement).value = '#f50000';
   fireEvent.input(input, '#f50000');
 
-  expect(props.onChange).toHaveBeenCalledWith(
-    '<p><span style="color: #f50000">test</span></p>'
+  await waitFor(
+    () =>
+      expect(props.onChange).toHaveBeenCalledWith(
+        '<p><span style="color: #f50000">test</span></p>'
+      ),
+    { timeout: 2000 }
   );
 });
 


### PR DESCRIPTION

# Description

- This PR fixes 'isBetweenDates' not working if passing in a string date


