### PR TITLE
💄 Select menu child item spacing with multiline text issue

### DIFF
--- a/src/molecules/Select/Select.styles.ts
+++ b/src/molecules/Select/Select.styles.ts
@@ -249,6 +249,7 @@ const MenuItemSpacer = styled.hr`
   height: calc(100% + ${spacings.medium} * 2);
   justify-self: center;
   width: ${spacings.x_large};
+  min-width: ${spacings.x_large};
 `;
 
 const PlaceholderText = styled(Typography)`


### PR DESCRIPTION
We have this issue in PWEX. Spacers are shrinking if not set min-width.

https://dev.azure.com/Equinor/DPP%20Upscaling%20of%20digital%20solutions/_boards/board/t/PWEX/Stories?System.AssignedTo=ARST%40equinor.com&workitem=568972