### PR TITLE
:bug: Fix really long filenames not working with FileProgress

### DIFF
--- a/src/molecules/FileProgress/FileProgress.stories.tsx
+++ b/src/molecules/FileProgress/FileProgress.stories.tsx
@@ -92,6 +92,25 @@ export const Default: Story = {
   },
 };
 
+export const ReallyLongFileName: Story = {
+  args: {
+    indeterminate: true,
+    isDone: true,
+
+    file: new File(
+      [
+        new ArrayBuffer(
+          faker.number.int({ min: Math.pow(10, 7), max: Math.pow(10, 9) })
+        ),
+      ],
+      `${(faker.string.uuid() + faker.string.uuid()).replaceAll('-', '')}.${faker.system.fileExt('image/png')}`,
+      {
+        type: 'image/png',
+      }
+    ),
+  },
+};
+
 export const Compact: Story = {
   args: {
     indeterminate: true,

--- a/src/molecules/FileProgress/RegularFileProgress.styles.tsx
+++ b/src/molecules/FileProgress/RegularFileProgress.styles.tsx
@@ -32,8 +32,10 @@ export const RegularFileProgressWrapper = styled.div`
 export const FileName = styled.div`
   display: flex;
   align-items: center;
+  gap: ${spacings.small};
   justify-content: space-between;
   min-height: 40px;
+  word-break: break-word;
 `;
 
 export const RegularFileProgressDetails = styled.div`


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#636916](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/636916)

---

- [ ] Needs to be tested locally by reviewer

# Description

- This PR fixes the FileProgress component not breaking really long words as expected, causing the icon to be squished

---
Before:
![image](https://github.com/user-attachments/assets/1296394d-6279-4c2a-ae85-b95d7844e801)



After:
![image](https://github.com/user-attachments/assets/6bee7631-0baf-414b-a086-ea1a62cb005a)

