### PR TITLE
:sparkles: Added 'customValueComponent' prop to SingleSelect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-component-lib",
-  "version": "9.12.0",
+  "version": "9.13.0",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/molecules/Select/Select.tsx
+++ b/src/molecules/Select/Select.tsx
@@ -117,7 +117,14 @@ export const Select = <T extends SelectOptionRequired>(
   /* v8 ignore end */
 
   const valueElements = useMemo(() => {
-    if ('value' in props && props.value) {
+    if (
+      'value' in props &&
+      props.value &&
+      'customValueComponent' in props &&
+      props.customValueComponent
+    ) {
+      return <props.customValueComponent item={props.value} />;
+    } else if ('value' in props && props.value) {
       return <ValueText>{props.value.label}</ValueText>;
     } else if ('showSelectedAsText' in props && props.showSelectedAsText) {
       const totalAmount = props.items

--- a/src/molecules/Select/Select.types.ts
+++ b/src/molecules/Select/Select.types.ts
@@ -14,6 +14,9 @@ export type SelectOption<T extends SelectOptionRequired> = T & {
 export interface SingleSelectCommon<T extends SelectOptionRequired> {
   value: SelectOption<T> | undefined;
   onSelect: (value: SelectOption<T> | undefined) => void;
+  customValueComponent?: FC<{
+    item: SelectOption<T>;
+  }>;
 }
 
 interface MultiSelectBase<T extends SelectOptionRequired> {

--- a/src/molecules/Select/SingleSelect/SingleSelect.stories.tsx
+++ b/src/molecules/Select/SingleSelect/SingleSelect.stories.tsx
@@ -1,9 +1,12 @@
 import { FC, useState } from 'react';
 
+import { boat, car, flight } from '@equinor/eds-icons';
 import { faker } from '@faker-js/faker';
 import { actions } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
 
+import { colors, spacings } from 'src/atoms';
+import { Icon } from 'src/molecules';
 import {
   SelectedState,
   SelectOption,
@@ -173,6 +176,86 @@ export const SingleSelectWithCustomizableSelectMenuItem: StoryFn = (args) => {
       value={value}
       onSelect={handleOnSelect}
       CustomMenuItemComponent={CustomMenuItem}
+    />
+  );
+};
+
+function getIcon(value: 'car' | 'airplane' | 'boat') {
+  switch (value) {
+    case 'car':
+      return car;
+    case 'airplane':
+      return flight;
+    case 'boat':
+      return boat;
+  }
+}
+
+const CustomValueComponent: FC<{
+  item: {
+    value: 'car' | 'airplane' | 'boat';
+    label: 'Car' | 'Airplane' | 'Boat';
+  };
+}> = ({ item }) => {
+  return (
+    <div
+      style={{ display: 'flex', gap: spacings.x_small, alignItems: 'center' }}
+    >
+      <Icon
+        data={getIcon(item.value)}
+        color={colors.text.static_icons__tertiary.rgba}
+      />
+      {item.label}
+    </div>
+  );
+};
+
+export const SingleSelectWithCustomValueComponent: StoryFn = (args) => {
+  const [value, setValue] = useState<
+    SelectOption<{
+      value: 'car' | 'airplane' | 'boat';
+      label: 'Car' | 'Airplane' | 'Boat';
+    }>
+  >({
+    value: 'car',
+    label: 'Car',
+  });
+
+  const handleOnSelect = (
+    selectedValue:
+      | SelectOption<{
+          value: 'car' | 'airplane' | 'boat';
+          label: 'Car' | 'Airplane' | 'Boat';
+        }>
+      | undefined
+  ) => {
+    if (selectedValue === undefined) return;
+
+    actions('onSelect').onSelect(selectedValue);
+    setValue(selectedValue);
+  };
+
+  return (
+    <SingleSelect
+      {...args}
+      items={[
+        {
+          value: 'car',
+          label: 'Car',
+        },
+        {
+          value: 'airplane',
+          label: 'Airplane',
+        },
+        {
+          value: 'boat',
+          label: 'Boat',
+        },
+      ]}
+      value={value}
+      onSelect={handleOnSelect}
+      customValueComponent={CustomValueComponent}
+      clearable={false}
     />
   );
 };

--- a/src/molecules/Select/SingleSelect/SingleSelect.test.tsx
+++ b/src/molecules/Select/SingleSelect/SingleSelect.test.tsx
@@ -1,6 +1,9 @@
+import { boat, car, flight } from '@equinor/eds-icons';
 import { faker } from '@faker-js/faker';
 
 import { SingleSelect } from './SingleSelect';
+import { colors, spacings } from 'src/atoms';
+import { Icon } from 'src/molecules';
 import { fakeGroups } from 'src/molecules/Select/Select.test';
 import {
   fakeSelectItems,
@@ -254,4 +257,74 @@ test('Custom menu item renders as expected', async () => {
   await user.click(screen.getByRole('combobox'));
 
   expect(screen.getByText(`custom item - ${value.value}`)).toBeInTheDocument();
+});
+
+test('Custom value component works as expected', async () => {
+  const label = faker.animal.bear();
+  const items = [
+    {
+      value: 'car',
+      label: 'Car',
+    },
+    {
+      value: 'airplane',
+      label: 'Airplane',
+    },
+    {
+      value: 'boat',
+      label: 'Boat',
+    },
+  ];
+  const value = items[0];
+
+  const handler = vi.fn();
+
+  render(
+    <SingleSelect
+      label={label}
+      onSelect={handler}
+      items={items}
+      value={value}
+      customValueComponent={({ item }) => {
+        function getIcon(value: string) {
+          switch (value) {
+            case 'car':
+              return car;
+            case 'airplane':
+              return flight;
+            case 'boat':
+            default:
+              return boat;
+          }
+        }
+
+        return (
+          <div
+            style={{
+              display: 'flex',
+              gap: spacings.x_small,
+              alignItems: 'center',
+            }}
+          >
+            <Icon
+              data={getIcon(item.value)}
+              color={colors.text.static_icons__tertiary.rgba}
+            />
+            {item.label}
+          </div>
+        );
+      }}
+    />
+  );
+
+  expect(
+    within(screen.getByText(value.label).parentElement!).getByTestId(
+      'eds-icon-path'
+    )
+  ).toBeInTheDocument();
+  expect(
+    within(screen.getByText(value.label).parentElement!).getByTestId(
+      'eds-icon-path'
+    )
+  ).toHaveAttribute('d', car.svgPathData);
 });


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#644200](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/644200)

---

- [ ] Needs to be tested locally by reviewer

# Description

- This PR adds the ability to have custom value component for single selects

