### PR TITLE
:sparkles: Added auto complete functionality to Filter component

### DIFF
--- a/src/organisms/Filter/AutoCompleteMenu.tsx
+++ b/src/organisms/Filter/AutoCompleteMenu.tsx
@@ -1,0 +1,112 @@
+import { KeyboardEvent, useEffect, useRef, useState } from 'react';
+
+import { Menu, Typography } from '@equinor/eds-core-react';
+
+import { colors } from 'src/atoms';
+import { FilterWithAutoCompleteOptions } from 'src/organisms/Filter/Filter.types';
+import {
+  findStartAndEndIndexOfSearch,
+  getFilteredAutoCompleteOptions,
+} from 'src/organisms/Filter/Filter.utils';
+
+import { styled } from 'styled-components';
+
+const StyledMenu = styled(Menu)`
+  overflow-y: auto;
+  max-height: 250px;
+`;
+
+const MatchingText = styled(Typography)`
+  color: ${colors.text.static_icons__tertiary.rgba};
+  > strong {
+    color: ${colors.text.static_icons__default.rgba};
+    font-weight: unset;
+  }
+`;
+
+interface AutoCompleteMenuProps<T extends string> {
+  anchorElement: HTMLElement | null;
+  searchElement: HTMLElement | null;
+  search: string;
+  isFilterOpen: boolean;
+  autoCompleteOptions: FilterWithAutoCompleteOptions<T>['autoCompleteOptions'];
+  onAutoComplete: FilterWithAutoCompleteOptions<T>['onAutoComplete'];
+}
+
+export function AutoCompleteMenu<T extends string>({
+  anchorElement,
+  searchElement,
+  search,
+  isFilterOpen,
+  autoCompleteOptions,
+  onAutoComplete,
+}: AutoCompleteMenuProps<T>) {
+  const [open, setOpen] = useState(false);
+  const previousSearch = useRef<string>('');
+
+  useEffect(() => {
+    if (!open && search !== previousSearch.current) {
+      previousSearch.current = search;
+      setOpen(true);
+    } else if (search !== previousSearch.current) {
+      previousSearch.current = search;
+    }
+  }, [open, search]);
+
+  const filteredItems = getFilteredAutoCompleteOptions({
+    searchValue: search,
+    autoCompleteOptions,
+  });
+
+  const handleOnKeyDown = (event: KeyboardEvent, index: number) => {
+    if (event.key === 'ArrowUp' && index === 0) {
+      event.preventDefault();
+      searchElement?.focus();
+      return;
+    }
+
+    if (event.key === 'Enter' && filteredItems[index]) {
+      onAutoComplete(filteredItems[index].key, filteredItems[index]);
+      setOpen(false);
+      return;
+    }
+  };
+
+  if (!isFilterOpen || !open || !search || filteredItems.length === 0)
+    return null;
+
+  return (
+    <StyledMenu
+      open
+      anchorEl={anchorElement}
+      matchAnchorWidth
+      onClose={() => {
+        setOpen(false);
+      }}
+    >
+      {filteredItems.map((item, index) => {
+        const [startIndex, endIndex] = findStartAndEndIndexOfSearch({
+          searchValue: search,
+          label: item.label,
+        });
+
+        const elements = [
+          item.label.slice(0, startIndex),
+          <strong key={`${item.value}-start`}>
+            {item.label.slice(startIndex, endIndex + 1)}
+          </strong>,
+          item.label.slice(endIndex + 1),
+        ];
+
+        return (
+          <Menu.Item
+            key={item.value}
+            onKeyDown={(event) => handleOnKeyDown(event, index)}
+          >
+            <MatchingText>{elements}</MatchingText>
+          </Menu.Item>
+        );
+      })}
+    </StyledMenu>
+  );
+}

--- a/src/organisms/Filter/AutoCompleteText.tsx
+++ b/src/organisms/Filter/AutoCompleteText.tsx
@@ -1,0 +1,54 @@
+import { Typography } from '@equinor/eds-core-react';
+
+import { colors } from 'src/atoms';
+import { FilterWithAutoCompleteOptions } from 'src/organisms/Filter/Filter.types';
+import {
+  findStartAndEndIndexOfSearch,
+  getFilteredAutoCompleteOptions,
+} from 'src/organisms/Filter/Filter.utils';
+
+import { styled } from 'styled-components';
+
+export const StyledTypography = styled(Typography)`
+  position: absolute;
+  left: 0;
+  color: ${colors.text.static_icons__tertiary.rgba};
+  top: 50%;
+  transform: translateY(-50%);
+  text-wrap: nowrap;
+  > span {
+    color: transparent;
+  }
+`;
+
+interface AutoCompleteTextProps<T extends string> {
+  search: string;
+  autoCompleteOptions: FilterWithAutoCompleteOptions<T>['autoCompleteOptions'];
+}
+
+export function AutoCompleteText<T extends string>({
+  search,
+  autoCompleteOptions,
+}: AutoCompleteTextProps<T>) {
+  const filteredOptions = getFilteredAutoCompleteOptions({
+    autoCompleteOptions,
+    searchValue: search,
+  });
+
+  if (filteredOptions.length === 0) return null;
+
+  const item = filteredOptions[0];
+  const [startIndex, endIndex] = findStartAndEndIndexOfSearch({
+    searchValue: search,
+    label: item.label,
+  });
+
+  if (startIndex !== 0) return null;
+
+  return (
+    <StyledTypography>
+      <span>{search.slice(0, search.length)}</span>
+      {item.label.slice(endIndex + 1)}
+    </StyledTypography>
+  );
+}

--- a/src/organisms/Filter/Filter.stories.tsx
+++ b/src/organisms/Filter/Filter.stories.tsx
@@ -32,6 +32,7 @@ type FilterStoryProps = FilterProps<string> & {
   withSorting?: boolean;
   withQuickFilter?: boolean;
   withTabs?: boolean;
+  withAutoComplete?: boolean;
 };
 
 const Wrapper: FC<FilterStoryProps> = (props) => {
@@ -159,6 +160,19 @@ const Wrapper: FC<FilterStoryProps> = (props) => {
     }
   };
 
+  const handleOnAutoComplete = (key: string, value: SelectOptionRequired) => {
+    switch (key) {
+      case 'manufacturer':
+        setManufacturer((prev) => [...prev, value]);
+        break;
+      case 'carSize':
+        setCarSize(value);
+        break;
+    }
+
+    setSearch('');
+  };
+
   return (
     <Filter
       {...props}
@@ -168,6 +182,15 @@ const Wrapper: FC<FilterStoryProps> = (props) => {
       onSearchChange={handleOnSearchChange}
       onClearFilter={handleOnClearFilter}
       onClearAllFilters={handleOnClearAllFilters}
+      autoCompleteOptions={
+        props.withAutoComplete
+          ? {
+              carSize: CAR_SIZE,
+              manufacturer: MANUFACTURERS,
+            }
+          : undefined
+      }
+      onAutoComplete={props.withAutoComplete ? handleOnAutoComplete : undefined}
       topContent={
         props.withTabs ? (
           <Tabs
@@ -386,5 +409,12 @@ export const WithTopContent: Story = {
     values: {
       manufacturer: faker.helpers.arrayElements(MANUFACTURERS, 1),
     },
+  },
+};
+
+export const WithAutoComplete: Story = {
+  args: {
+    withAutoComplete: true,
+    values: {},
   },
 };

--- a/src/organisms/Filter/Filter.styles.ts
+++ b/src/organisms/Filter/Filter.styles.ts
@@ -128,3 +128,9 @@ export const StyledChip = styled(Chip)<StyledChipProps>`
     }
   }}
 `;
+
+export const SearchFieldWrapper = styled.section`
+  position: relative;
+  flex-grow: 1;
+  display: flex;
+`;

--- a/src/organisms/Filter/Filter.types.ts
+++ b/src/organisms/Filter/Filter.types.ts
@@ -18,11 +18,14 @@ interface CommonFilterProps<T extends string> {
   placeholder?: string;
   id?: string;
 }
-// Going to be used later
-// type FilterWithAutoCompleteOptions<T extends string> = CommonFilterProps<T> & {
-//   autoCompleteOptions: Record<T, SelectOptionRequired[]>;
-//   onAutoComplete: (key: T, value: SelectOptionRequired) => void;
-// };
 
-export type FilterProps<T extends string> = CommonFilterProps<T>;
-// | FilterWithAutoCompleteOptions<T>;
+export interface FilterWithAutoCompleteOptions<T extends string>
+  extends CommonFilterProps<T> {
+  autoCompleteOptions: Record<T, SelectOptionRequired[]>;
+  onAutoComplete: (key: T, value: SelectOptionRequired) => void;
+  onSearchEnter: (value: string) => void;
+}
+
+export type FilterProps<T extends string> =
+  | CommonFilterProps<T>
+  | FilterWithAutoCompleteOptions<T>;

--- a/src/organisms/Filter/Filter.utils.ts
+++ b/src/organisms/Filter/Filter.utils.ts
@@ -1,0 +1,65 @@
+import { SelectOption, SelectOptionRequired } from 'src/molecules';
+
+function filterAutoCompleteOption<T extends SelectOptionRequired>({
+  searchValue,
+  option,
+}: {
+  searchValue: string;
+  option: SelectOption<T>;
+}) {
+  if (searchValue === '') return false;
+  return option.label.toLowerCase().includes(searchValue.toLowerCase());
+}
+
+function getAllAutoCompleteOptions<T extends string>(
+  autoCompleteOptions: Record<T, SelectOptionRequired[]>
+): Array<SelectOptionRequired & { key: T }> {
+  const all: Array<SelectOptionRequired & { key: T }> = [];
+  for (const key in autoCompleteOptions) {
+    all.push(...autoCompleteOptions[key].map((option) => ({ ...option, key })));
+  }
+  return all;
+}
+
+function sortByMatchPercentage({
+  a,
+  b,
+  searchValue,
+}: {
+  a: string;
+  b: string;
+  searchValue: string;
+}) {
+  const searchToLower = searchValue.toLowerCase();
+  const restA = a.toLowerCase().replace(searchToLower, '');
+  const restB = b.toLowerCase().replace(searchToLower, '');
+
+  return restA.length - restB.length;
+}
+
+export function getFilteredAutoCompleteOptions<T extends string>({
+  searchValue,
+  autoCompleteOptions,
+}: {
+  searchValue: string;
+  autoCompleteOptions: Record<T, SelectOptionRequired[]>;
+}): Array<SelectOptionRequired & { key: T }> {
+  return getAllAutoCompleteOptions(autoCompleteOptions)
+    .filter((option) => filterAutoCompleteOption({ searchValue, option }))
+    .sort((a, b) =>
+      sortByMatchPercentage({ a: a.label, b: b.label, searchValue })
+    )
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export function findStartAndEndIndexOfSearch({
+  searchValue,
+  label,
+}: {
+  searchValue: string;
+  label: string;
+}): [number, number] {
+  const startIndex = label.toLowerCase().indexOf(searchValue.toLowerCase());
+  if (startIndex === -1) return [-1, -1];
+  return [startIndex, startIndex + searchValue.length - 1];
+}


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#610010](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/610010)

### Tasks
- [AB#650831](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/650831)

---

- [ ] Needs to be tested locally by reviewer

# Description

- This PR adds 'autoCompleteOptions' and 'onAutoComplete' to Filter component
