### PR TITLE
:lipstick: New active/inactive tutorial step darkmode colors

### DIFF
--- a/src/atoms/style/colors.ts
+++ b/src/atoms/style/colors.ts
@@ -23,6 +23,12 @@ export const colors = {
     primary__pressed: {
       rgba: 'var(--amplify_interactive_primary_pressed, rgba(19, 46, 49, 1))',
     },
+    tutorial__active_step: {
+      rgba: 'var(--amplify_interactive_tutorial_active_step, rgba(0, 112, 121, 1))',
+    },
+    tutorial__inactive_step: {
+      rgba: 'var(--amplify_interactive_tutorial_inactive_step, rgba(168, 206, 209, 1))',
+    },
   },
   dataviz: {
     primary: {

--- a/src/atoms/style/darkTokens.ts
+++ b/src/atoms/style/darkTokens.ts
@@ -8,6 +8,9 @@ export const darkTokens = css`
       color: var(--eds_text_static_icons__default);
     }
 
+    --amplify_interactive_tutorial_active_step: rgba(154, 202, 206, 1);
+    --amplify_interactive_tutorial_inactive_step: rgba(96, 125, 127, 1);
+
     /* Override super specific text colors to just default text color */
     --eds_heading__h1_bold_color: var(--eds_text_static_icons__default);
     --eds_input__text_monospaced_color: var(--eds_text_static_icons__default);

--- a/src/atoms/style/lightTokens.ts
+++ b/src/atoms/style/lightTokens.ts
@@ -7,6 +7,8 @@ export const lightTokens = css`
     --amplify_ui_background_tutorial_card: rgba(222, 237, 238, 1);
 
     --amplify_interactive_primary_pressed: rgba(19, 46, 49, 1);
+    --amplify_interactive_tutorial_active_step: rgba(0, 112, 121, 1);
+    --amplify_interactive_tutorial_inactive_step: rgba(168, 206, 209, 1);
 
     --amplify_dataviz_primary_default: rgba(0, 107, 229, 1);
     --amplify_dataviz_primary_darker: rgba(0, 83, 178, 1);

--- a/src/providers/TutorialHighlightingProvider/TutorialPopover/StepIndicator.tsx
+++ b/src/providers/TutorialHighlightingProvider/TutorialPopover/StepIndicator.tsx
@@ -20,13 +20,13 @@ const Step = styled.span<StepProps>`
   overflow: hidden;
   height: 4px;
   width: 100%;
-  background: ${colors.infographic.primary__moss_green_34.rgba};
+  background: ${colors.interactive.tutorial__inactive_step.rgba};
   border-radius: ${shape.rounded.borderRadius};
   position: relative;
   &:after {
     content: '';
     position: absolute;
-    background: ${colors.interactive.primary__resting.rgba};
+    background: ${colors.interactive.tutorial__active_step.rgba};
     width: 100%;
     height: 100%;
     transition: left ${animation.transitionMS};


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#647528](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/647528)

### Tasks
- [AB#648886](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/648886)

---

- [ ] Needs to be tested locally by reviewer

# Description

- This PR adds/fixes the colors for the stepper in a tutorial card


