### PR TITLE
Feat/add-highlighting-extension-to-rich-text-editor

### DIFF
--- a/src/molecules/RichTextEditor/MenuBar/AddImageButton.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/AddImageButton.tsx
@@ -59,6 +59,7 @@ export const AddImageButton: FC<AddImageProps> = ({
         data-testid="add-image-button"
         icon={camera_add_photo}
         onClick={showFileDialog}
+        tooltip="Add Image"
       />
     </>
   );

--- a/src/molecules/RichTextEditor/MenuBar/MenuBar.styles.ts
+++ b/src/molecules/RichTextEditor/MenuBar/MenuBar.styles.ts
@@ -8,16 +8,22 @@ const { spacings, shape } = tokens;
 
 export const MenuSection = styled.section`
   display: flex;
-  > button:not(:first-child):not(:last-child) {
-    border-radius: 0;
+  > div:not(:first-child):not(:last-child) {
+    > button {
+      border-radius: 0;
+    }
   }
-  > button:first-child {
-    border-bottom-right-radius: 0;
-    border-top-right-radius: 0;
+  > div:first-child {
+    > button {
+      border-bottom-right-radius: 0;
+      border-top-right-radius: 0;
+    }
   }
-  > button:last-child {
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
+  > div:last-child {
+    > button {
+      border-bottom-left-radius: 0;
+      border-top-left-radius: 0;
+    }
   }
 `;
 

--- a/src/molecules/RichTextEditor/MenuBar/MenuBar.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/MenuBar.tsx
@@ -88,7 +88,7 @@ export const EditorMenu = {
 
 export const EditorText = {
   History: TextHistory,
-  Formating: TextFormatting,
+  Formatting: TextFormatting,
   Headers: TextHeaders,
   Lists: TextLists,
   Color: TextColor,
@@ -97,6 +97,6 @@ export const EditorText = {
   Table: TextTable,
   TableBar: TableMenuBar,
   Alignment: TextAlignment,
-  ClearFormating: TextClearFormatting,
+  ClearFormatting: TextClearFormatting,
 };
 /* v8 ignore end */

--- a/src/molecules/RichTextEditor/MenuBar/MenuBar.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/MenuBar.tsx
@@ -15,6 +15,7 @@ import { TextAlignment } from './TextAlignment';
 import { TextCode } from './TextCode';
 import { TextColor } from './TextColor';
 import { TextHeaders } from './TextHeaders';
+import { TextHighlight } from './TextHighlight';
 import { TextHistory } from './TextHistory';
 import { TextLinks } from './TextLinks';
 import { TextLists } from './TextLists';
@@ -59,6 +60,7 @@ export const AmplifyBar: FC<MenuBarProps> = ({
         <TextHeaders editor={editor} features={features} />
         <TextLists editor={editor} features={features} />
         <TextColor editor={editor} features={features} />
+        <TextHighlight editor={editor} features={features} />
         <TextCode editor={editor} features={features} />
         <TextAlignment editor={editor} features={features} />
         <TextLinks editor={editor} features={features} />

--- a/src/molecules/RichTextEditor/MenuBar/MenuButton.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/MenuButton.tsx
@@ -4,7 +4,7 @@ import { Icon } from '@equinor/eds-core-react';
 import { IconData } from '@equinor/eds-icons';
 
 import { MenuButtonStyle } from './MenuBar.styles';
-import { OptionalTooltip } from 'src/molecules/OptionalTooltip/OptionalTooltip';
+import { OptionalTooltip } from 'src/index';
 
 export interface MenuButtonProps {
   ref?: RefObject<HTMLButtonElement>;
@@ -28,21 +28,25 @@ export const MenuButton = forwardRef<HTMLButtonElement, MenuButtonProps>(
       ...props
     },
     ref
-  ) => (
-    <OptionalTooltip title={tooltip} placement="bottom">
-      <MenuButtonStyle
-        ref={ref}
-        $active={active}
-        onClick={onClick}
-        disabled={disabled}
-        type="button"
-        {...props}
-      >
-        <Icon data={icon} />
-        {children}
-      </MenuButtonStyle>
-    </OptionalTooltip>
-  )
+  ) => {
+    return (
+      <OptionalTooltip title={tooltip} enterDelay={300}>
+        <div>
+          <MenuButtonStyle
+            ref={ref}
+            $active={active}
+            onClick={onClick}
+            disabled={disabled}
+            type="button"
+            {...props}
+          >
+            <Icon data={icon} />
+            {children}
+          </MenuButtonStyle>
+        </div>
+      </OptionalTooltip>
+    );
+  }
 );
 
 MenuButton.displayName = 'MenuButton';

--- a/src/molecules/RichTextEditor/MenuBar/Table/Table.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/Table/Table.tsx
@@ -24,6 +24,7 @@ export const TextTable: FC<EditorPanel> = ({ editor, features }) => {
           .insertTable({ rows: 1, cols: 3, withHeaderRow: false })
           .run();
       }}
+      tooltip="Add Table"
     />
   );
 };

--- a/src/molecules/RichTextEditor/MenuBar/TextAlignment.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextAlignment.tsx
@@ -21,18 +21,21 @@ export const TextAlignment: FC<EditorPanel> = ({ editor, features }) => {
         data-testid="align-left-button"
         icon={format_align_left}
         onClick={alignLeft}
+        tooltip="Align Left"
       />
       <EditorMenu.Button
         active={editor.isActive({ textAlign: 'center' })}
         data-testid="align-center-button"
         icon={format_align_center}
         onClick={alignCenter}
+        tooltip="Align Center"
       />
       <EditorMenu.Button
         active={editor.isActive({ textAlign: 'right' })}
         data-testid="align-right-button"
         icon={format_align_right}
         onClick={alignRight}
+        tooltip="Align Right"
       />
     </EditorMenu.Section>
   );

--- a/src/molecules/RichTextEditor/MenuBar/TextClearFormatting.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextClearFormatting.tsx
@@ -27,6 +27,7 @@ export const TextClearFormatting: FC<EditorPanel> = ({ editor, features }) => {
         icon={format_clear}
         onClick={clearFormatting}
         data-testid="clear-formatting"
+        tooltip="Clear Formatting"
       />
     </>
   );

--- a/src/molecules/RichTextEditor/MenuBar/TextCode.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextCode.tsx
@@ -14,6 +14,7 @@ export const TextCode: FC<EditorPanel> = ({ editor, features }) => {
       icon={code}
       onClick={toggleCode}
       data-testid="code-button"
+      tooltip="Code Block"
     />
   );
 };

--- a/src/molecules/RichTextEditor/MenuBar/TextColor.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextColor.tsx
@@ -5,6 +5,7 @@ import { format_color_text } from '@equinor/eds-icons';
 import { tokens } from '@equinor/eds-tokens';
 
 import { EditorPanel, RichTextEditorFeatures } from '../RichTextEditor.types';
+import { OptionalTooltip } from 'src/molecules/OptionalTooltip/OptionalTooltip';
 
 import styled from 'styled-components';
 
@@ -68,26 +69,28 @@ export const TextColor: FC<EditorPanel> = ({ editor, features }) => {
   if (features && !features.includes(RichTextEditorFeatures.TEXT_COLOR))
     return null;
   return (
-    <TextColorStyle>
-      <input
-        type="color"
-        onInput={handleOnInput}
-        data-testid="text-color-input"
-        value={
-          (editor.getAttributes('textStyle')?.color as string) ||
-          colors.text.static_icons__default.hex
-        }
-      />
-      <IconWrapper>
-        <Icon data={format_color_text} />
-      </IconWrapper>
-      <ColorBar
-        style={{
-          background:
+    <OptionalTooltip title="Text Color" enterDelay={300}>
+      <TextColorStyle>
+        <input
+          type="color"
+          onInput={handleOnInput}
+          data-testid="text-color-input"
+          value={
             (editor.getAttributes('textStyle')?.color as string) ||
-            colors.text.static_icons__default.hex,
-        }}
-      />
-    </TextColorStyle>
+            colors.text.static_icons__default.hex
+          }
+        />
+        <IconWrapper>
+          <Icon data={format_color_text} />
+        </IconWrapper>
+        <ColorBar
+          style={{
+            background:
+              (editor.getAttributes('textStyle')?.color as string) ||
+              colors.text.static_icons__default.hex,
+          }}
+        />
+      </TextColorStyle>
+    </OptionalTooltip>
   );
 };

--- a/src/molecules/RichTextEditor/MenuBar/TextColor.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextColor.tsx
@@ -5,7 +5,7 @@ import { format_color_text } from '@equinor/eds-icons';
 import { tokens } from '@equinor/eds-tokens';
 
 import { EditorPanel, RichTextEditorFeatures } from '../RichTextEditor.types';
-import { OptionalTooltip } from 'src/molecules/OptionalTooltip/OptionalTooltip';
+import { OptionalTooltip } from 'src/index';
 
 import styled from 'styled-components';
 

--- a/src/molecules/RichTextEditor/MenuBar/TextFormatting.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextFormatting.tsx
@@ -18,12 +18,14 @@ export const TextFormatting: FC<EditorPanel> = ({ editor, features }) => {
         data-testid="bold-button"
         icon={format_bold}
         onClick={toggleBold}
+        tooltip="Bold"
       />
       <EditorMenu.Button
         active={editor.isActive('italic')}
         data-testid="italic-button"
         icon={format_italics}
         onClick={toggleItalic}
+        tooltip="Italic"
       />
     </EditorMenu.Section>
   );

--- a/src/molecules/RichTextEditor/MenuBar/TextHeaders.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextHeaders.tsx
@@ -18,12 +18,14 @@ export const TextHeaders: FC<EditorPanel> = ({ editor, features }) => {
         active={editor.isActive('heading', { level: 2 })}
         icon={amplify_h2}
         onClick={toggleH2}
+        tooltip="Heading 2"
       />
       <EditorMenu.Button
         data-testid="h3-button"
         active={editor.isActive('heading', { level: 3 })}
         icon={amplify_h3}
         onClick={toggleH3}
+        tooltip="Heading 3"
       />
     </EditorMenu.Section>
   );

--- a/src/molecules/RichTextEditor/MenuBar/TextHighlight.test.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextHighlight.test.tsx
@@ -3,7 +3,11 @@ import {
   RichTextEditorFeatures,
   RichTextEditorProps,
 } from 'src/molecules';
-import { renderWithProviders, screen } from 'src/tests/browsertest-utils';
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+} from 'src/tests/browsertest-utils';
 
 function fakeProps(): RichTextEditorProps {
   return {
@@ -26,4 +30,24 @@ test('Hides button if not in features', async () => {
   const input = screen.queryByTestId('highlight-button');
 
   expect(input).not.toBeInTheDocument();
+});
+
+test('Highlights text when button is clicked', async () => {
+  const props = fakeProps();
+  renderWithProviders(
+    <RichTextEditor
+      {...props}
+      removeFeatures={[RichTextEditorFeatures.IMAGES]}
+    />
+  );
+  const user = userEvent.setup();
+
+  const button = await screen.findByTestId('highlight-button');
+
+  expect(button).toBeInTheDocument();
+
+  await user.dblClick(screen.getByText('test'));
+  await user.click(button);
+
+  expect(props.onChange).toHaveBeenCalledWith('<p><mark>test</mark></p>');
 });

--- a/src/molecules/RichTextEditor/MenuBar/TextHighlight.test.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextHighlight.test.tsx
@@ -16,7 +16,10 @@ test('Hides button if not in features', async () => {
   renderWithProviders(
     <RichTextEditor
       {...fakeProps()}
-      removeFeatures={[RichTextEditorFeatures.HIGHLIGHT]}
+      removeFeatures={[
+        RichTextEditorFeatures.IMAGES,
+        RichTextEditorFeatures.HIGHLIGHT,
+      ]}
     />
   );
 

--- a/src/molecules/RichTextEditor/MenuBar/TextHighlight.test.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextHighlight.test.tsx
@@ -1,0 +1,26 @@
+import {
+  RichTextEditor,
+  RichTextEditorFeatures,
+  RichTextEditorProps,
+} from 'src/molecules';
+import { renderWithProviders, screen } from 'src/tests/browsertest-utils';
+
+function fakeProps(): RichTextEditorProps {
+  return {
+    value: `<p>test</p>`,
+    onChange: vi.fn(),
+  };
+}
+
+test('Hides button if not in features', async () => {
+  renderWithProviders(
+    <RichTextEditor
+      {...fakeProps()}
+      removeFeatures={[RichTextEditorFeatures.HIGHLIGHT]}
+    />
+  );
+
+  const input = screen.queryByTestId('highlight-button');
+
+  expect(input).not.toBeInTheDocument();
+});

--- a/src/molecules/RichTextEditor/MenuBar/TextHighlight.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextHighlight.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react';
+
+import { brush } from '@equinor/eds-icons';
+
+import { EditorPanel, RichTextEditorFeatures } from '../RichTextEditor.types';
+import { EditorMenu } from './MenuBar';
+
+export const TextHighlight: FC<EditorPanel> = ({ editor, features }) => {
+  if (features && !features.includes(RichTextEditorFeatures.HIGHLIGHT))
+    return null;
+
+  return (
+    <EditorMenu.Button
+      active={editor.isActive('highlight')}
+      icon={brush}
+      onClick={() => editor.chain().focus().toggleHighlight().run()}
+      data-testid="highlight-button"
+      tooltip="Highlight"
+    />
+  );
+};

--- a/src/molecules/RichTextEditor/MenuBar/TextHighlight.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextHighlight.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-import { brush } from '@equinor/eds-icons';
+import { format_color_fill } from '@equinor/eds-icons';
 
 import { EditorPanel, RichTextEditorFeatures } from '../RichTextEditor.types';
 import { EditorMenu } from './MenuBar';
@@ -12,7 +12,7 @@ export const TextHighlight: FC<EditorPanel> = ({ editor, features }) => {
   return (
     <EditorMenu.Button
       active={editor.isActive('highlight')}
-      icon={brush}
+      icon={format_color_fill} // A suitable icon for highlighting doesn't exist in EDS, using color fill as a placeholder
       onClick={() => editor.chain().focus().toggleHighlight().run()}
       data-testid="highlight-button"
       tooltip="Highlight"

--- a/src/molecules/RichTextEditor/MenuBar/TextHistory.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextHistory.tsx
@@ -17,12 +17,14 @@ export const TextHistory: FC<EditorPanel> = ({ editor, features }) => {
         onClick={onUndo}
         data-testid="undo-button"
         disabled={!editor.can().undo()}
+        tooltip="Undo"
       />
       <EditorMenu.Button
         icon={redo}
         onClick={onRedo}
         data-testid="redo-button"
         disabled={!editor.can().redo()}
+        tooltip="Redo"
       />
     </EditorMenu.Section>
   );

--- a/src/molecules/RichTextEditor/MenuBar/TextLinks.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextLinks.tsx
@@ -79,12 +79,14 @@ export const TextLinks: FC<EditorPanel> = ({ editor, features }) => {
           onClick={handleOnToggleOpen}
           disabled={editor.state.selection.empty}
           data-testid="link-button"
+          tooltip="Link"
         />
         <EditorMenu.Button
           icon={link_off}
           onClick={onUnsetLink}
           disabled={!editor.isActive('link')}
           data-testid="unsetlink-button"
+          tooltip="Remove Link"
         />
       </EditorMenu.Section>
       {open && (

--- a/src/molecules/RichTextEditor/MenuBar/TextLists.tsx
+++ b/src/molecules/RichTextEditor/MenuBar/TextLists.tsx
@@ -19,12 +19,14 @@ export const TextLists: FC<EditorPanel> = ({ editor, features }) => {
         icon={format_list_bulleted}
         onClick={toggleBulletList}
         data-testid="bullet-list-button"
+        tooltip="Bullet List"
       />
       <EditorMenu.Button
         active={editor.isActive('orderedList')}
         icon={format_list_numbered}
         onClick={toggleOrderedList}
         data-testid="ordered-list-button"
+        tooltip="Ordered List"
       />
     </EditorMenu.Section>
   );

--- a/src/molecules/RichTextEditor/RichTextEditor.types.ts
+++ b/src/molecules/RichTextEditor/RichTextEditor.types.ts
@@ -12,6 +12,7 @@ export enum RichTextEditorFeatures {
   IMAGES = 'images',
   CLEAR_FORMATTING = 'clear-formatting',
   TABLE = 'table',
+  HIGHLIGHT = 'highlight',
 }
 
 export const DEFAULT_FEATURES = [
@@ -26,6 +27,7 @@ export const DEFAULT_FEATURES = [
   RichTextEditorFeatures.IMAGES,
   RichTextEditorFeatures.TABLE,
   RichTextEditorFeatures.CLEAR_FORMATTING,
+  RichTextEditorFeatures.HIGHLIGHT,
 ];
 
 type OnImageUploadFn = (

--- a/src/molecules/RichTextEditor/RichTextEditor.types.ts
+++ b/src/molecules/RichTextEditor/RichTextEditor.types.ts
@@ -27,7 +27,6 @@ export const DEFAULT_FEATURES = [
   RichTextEditorFeatures.IMAGES,
   RichTextEditorFeatures.TABLE,
   RichTextEditorFeatures.CLEAR_FORMATTING,
-  RichTextEditorFeatures.HIGHLIGHT,
 ];
 
 type OnImageUploadFn = (


### PR DESCRIPTION
- [ ] Needs to be tested locally by reviewer

# Description

- This PR adds the highlighting extension to the RichTextEditor
- It also fixes the broken tooltip, and adds tooltips for each of the tiptap extensions