### PR TITLE
fix/tutorial-highlight-contentref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-component-lib",
-  "version": "9.14.0",
+  "version": "9.14.1",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/providers/TutorialHighlightingProvider/TutorialHighlightingProvider.stories.tsx
+++ b/src/providers/TutorialHighlightingProvider/TutorialHighlightingProvider.stories.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, useRef } from 'react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 
 import { Button, Card, Divider, Typography } from '@equinor/eds-core-react';
@@ -20,6 +20,79 @@ import { http, HttpResponse } from 'msw';
 
 const TUTORIAL_IDS = [faker.string.uuid(), faker.string.uuid()];
 
+function RouteComponent() {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  return (
+    <div
+      ref={contentRef}
+      style={{
+        maxWidth: '100vw',
+        maxHeight: '100vh',
+        overflow: 'auto',
+      }}
+      id="content"
+    >
+      <TutorialHighlightingProvider contentRef={contentRef}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            flexDirection: 'column',
+            alignItems: 'center',
+            padding: '10rem 0',
+            gap: '1rem',
+          }}
+        >
+          {TUTORIAL_IDS.map((id) => (
+            <Fragment key={id}>
+              <Card
+                style={{ padding: '1rem' }}
+                id={highlightTutorialElementID(id, 0)}
+              >
+                <Card.HeaderTitle>
+                  <Typography variant="h2">
+                    {faker.airline.airport().name +
+                      ' ' +
+                      faker.airline.airport().iataCode}
+                  </Typography>
+                </Card.HeaderTitle>
+                <Card.Actions>
+                  <Button variant="outlined">Stop</Button>
+                  <Button id={highlightTutorialElementID(id, 1)}>Start</Button>
+                </Card.Actions>
+              </Card>
+              <Card style={{ padding: '1rem' }}>
+                <Card.HeaderTitle>
+                  <Typography variant="h2">
+                    {faker.airline.airplane().name +
+                      ' ' +
+                      faker.airline.airplane().iataTypeCode}
+                  </Typography>
+                </Card.HeaderTitle>
+                <Button
+                  id={highlightTutorialElementID(id, 2)}
+                  variant="outlined"
+                  style={{ marginLeft: 'auto' }}
+                >
+                  Stop
+                </Button>
+              </Card>
+              <Divider />
+            </Fragment>
+          ))}
+          <Typography
+            id={highlightTutorialElementID(TUTORIAL_IDS[0], 3)}
+            style={{ marginTop: '80vh' }}
+          >
+            This is some text really far away
+          </Typography>
+        </div>
+      </TutorialHighlightingProvider>
+    </div>
+  );
+}
+
 const meta: Meta = {
   title: 'Providers/TutorialHighlightingProvider',
   component: function StoryComponent() {
@@ -29,75 +102,7 @@ const meta: Meta = {
           [
             {
               path: '/tutorial',
-              element: (
-                <div
-                  style={{
-                    maxWidth: '100vw',
-                    maxHeight: '100vh',
-                    overflow: 'auto',
-                  }}
-                  id="content"
-                >
-                  <TutorialHighlightingProvider>
-                    <div
-                      style={{
-                        display: 'flex',
-                        justifyContent: 'center',
-                        flexDirection: 'column',
-                        alignItems: 'center',
-                        padding: '10rem 0',
-                        gap: '1rem',
-                      }}
-                    >
-                      {TUTORIAL_IDS.map((id) => (
-                        <Fragment key={id}>
-                          <Card
-                            style={{ padding: '1rem' }}
-                            id={highlightTutorialElementID(id, 0)}
-                          >
-                            <Card.HeaderTitle>
-                              <Typography variant="h2">
-                                {faker.airline.airport().name +
-                                  ' ' +
-                                  faker.airline.airport().iataCode}
-                              </Typography>
-                            </Card.HeaderTitle>
-                            <Card.Actions>
-                              <Button variant="outlined">Stop</Button>
-                              <Button id={highlightTutorialElementID(id, 1)}>
-                                Start
-                              </Button>
-                            </Card.Actions>
-                          </Card>
-                          <Card style={{ padding: '1rem' }}>
-                            <Card.HeaderTitle>
-                              <Typography variant="h2">
-                                {faker.airline.airplane().name +
-                                  ' ' +
-                                  faker.airline.airplane().iataTypeCode}
-                              </Typography>
-                            </Card.HeaderTitle>
-                            <Button
-                              id={highlightTutorialElementID(id, 2)}
-                              variant="outlined"
-                              style={{ marginLeft: 'auto' }}
-                            >
-                              Stop
-                            </Button>
-                          </Card>
-                          <Divider />
-                        </Fragment>
-                      ))}
-                      <Typography
-                        id={highlightTutorialElementID(TUTORIAL_IDS[0], 3)}
-                        style={{ marginTop: '80vh' }}
-                      >
-                        This is some text really far away
-                      </Typography>
-                    </div>
-                  </TutorialHighlightingProvider>
-                </div>
-              ),
+              element: <RouteComponent />,
             },
           ],
           { initialEntries: ['/tutorial'] }

--- a/src/providers/TutorialHighlightingProvider/TutorialHighlightingProvider.test.tsx
+++ b/src/providers/TutorialHighlightingProvider/TutorialHighlightingProvider.test.tsx
@@ -1,4 +1,4 @@
-import { act, Fragment } from 'react';
+import { act, Fragment, useRef } from 'react';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 
 import { Button } from '@equinor/eds-core-react';
@@ -69,6 +69,8 @@ const TestComponent = ({
   setTutorialIds?: boolean;
 }) => {
   const queryClient = new QueryClient();
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
   return (
     <RouterProvider
       router={createMemoryRouter(
@@ -78,6 +80,7 @@ const TestComponent = ({
             element: (
               <QueryClientProvider client={queryClient}>
                 <div
+                  ref={contentRef}
                   style={{
                     maxWidth: '100vw',
                     height: '100vh',
@@ -86,6 +89,7 @@ const TestComponent = ({
                   id="content"
                 >
                   <TutorialHighlightingProvider
+                    contentRef={contentRef}
                     customStepContent={
                       withCustomContent ? CUSTOM_CONTENT : undefined
                     }

--- a/src/providers/TutorialHighlightingProvider/TutorialHighlightingProvider.tsx
+++ b/src/providers/TutorialHighlightingProvider/TutorialHighlightingProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, ReactElement, useContext } from 'react';
+import { createContext, FC, ReactElement, RefObject, useContext } from 'react';
 
 import { TutorialProvider } from '@equinor/subsurface-app-management';
 
@@ -24,17 +24,18 @@ export function useTutorialHighlighting() {
 
 interface TutorialHighlightingProviderProps {
   children: ReactElement | ReactElement[];
+  contentRef: RefObject<HTMLElement | null>;
   customStepContent?: Record<string, ReactElement>;
 }
 
 export const TutorialHighlightingProvider: FC<
   TutorialHighlightingProviderProps
-> = ({ children, customStepContent }) => (
+> = ({ children, contentRef, customStepContent }) => (
   <TutorialHighlightingContext.Provider
     value={{ customStepContent: customStepContent ?? {} }}
   >
     <TutorialProvider>
-      <TutorialHighlightingProviderInner>
+      <TutorialHighlightingProviderInner contentRef={contentRef}>
         {children}
       </TutorialHighlightingProviderInner>
     </TutorialProvider>

--- a/src/providers/TutorialHighlightingProvider/TutorialHighlightingProviderInner.tsx
+++ b/src/providers/TutorialHighlightingProvider/TutorialHighlightingProviderInner.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactElement, useEffect, useState } from 'react';
+import { FC, ReactElement, RefObject, useEffect, useState } from 'react';
 
 import { useTutorials } from '@equinor/subsurface-app-management';
 import { useIsFetching } from '@tanstack/react-query';
@@ -44,15 +44,16 @@ const Centered = styled.div`
 
 interface TutorialHighlightingProviderInnerProps {
   children: ReactElement | ReactElement[];
+  contentRef: RefObject<HTMLElement | null>;
 }
 
 export const TutorialHighlightingProviderInner: FC<
   TutorialHighlightingProviderInnerProps
-> = ({ children }) => {
+> = ({ children, contentRef }) => {
   const { activeTutorial, activeStep, unseenTutorialsOnThisPage } =
     useTutorials();
   const isFetching = useIsFetching() > 0;
-  const reversedScrollY = useReversedScrollY();
+  const reversedScrollY = useReversedScrollY(contentRef);
   const [windowSize, setWindowSize] = useState<{
     width: number;
     height: number;
@@ -141,6 +142,7 @@ export const TutorialHighlightingProviderInner: FC<
               <TutorialPopover
                 key={tutorial.id}
                 isHighlighting={highlightedTutorials.length > 0}
+                contentRef={contentRef}
                 {...tutorial}
                 {...highlight}
               />

--- a/src/providers/TutorialHighlightingProvider/TutorialPopover/TutorialPopover.tsx
+++ b/src/providers/TutorialHighlightingProvider/TutorialPopover/TutorialPopover.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react';
+import { FC, RefObject, useState } from 'react';
 
 import { Button, Card, Icon, Typography } from '@equinor/eds-core-react';
 import { info_circle } from '@equinor/eds-icons';
@@ -129,6 +129,7 @@ const Actions = styled.div`
 `;
 
 interface TutorialPopoverProps extends MyTutorialDto {
+  contentRef: RefObject<HTMLElement | null>;
   isHighlighting: boolean;
   top?: number;
   left?: number;
@@ -137,6 +138,7 @@ interface TutorialPopoverProps extends MyTutorialDto {
 }
 
 export const TutorialPopover: FC<TutorialPopoverProps> = ({
+  contentRef,
   isHighlighting,
   id,
   top,
@@ -167,6 +169,7 @@ export const TutorialPopover: FC<TutorialPopoverProps> = ({
   >(undefined);
   const { style, highlightingElement, caretPosition } =
     useTutorialPopoverPosition({
+      contentRef,
       top,
       left,
       width,

--- a/src/providers/TutorialHighlightingProvider/TutorialPopover/hooks/useTutorialPopoverPosition.ts
+++ b/src/providers/TutorialHighlightingProvider/TutorialPopover/hooks/useTutorialPopoverPosition.ts
@@ -1,3 +1,5 @@
+import { RefObject } from 'react';
+
 import { useReversedScrollY } from 'src/providers/TutorialHighlightingProvider/hooks/useReversedScrollY';
 
 import { MotionStyle, useTransform } from 'framer-motion';
@@ -5,6 +7,7 @@ import { MotionStyle, useTransform } from 'framer-motion';
 export const CARET_OFFSET = 16;
 
 interface UseTutorialPopoverPositionArgs {
+  contentRef: RefObject<HTMLElement | null>;
   top?: number;
   left?: number;
   width?: number;
@@ -33,8 +36,9 @@ export function useTutorialPopoverPosition({
   width,
   height,
   popoverSize,
+  contentRef,
 }: UseTutorialPopoverPositionArgs): UseTutorialPopoverPositionReturn {
-  const reversedScrollY = useReversedScrollY();
+  const reversedScrollY = useReversedScrollY(contentRef);
   // Default position of the popover is that it's under the highlighted element
   let usingTop = top && height ? top + height + CARET_OFFSET : undefined;
   let usingLeft = left && width ? left + width / 2 : undefined;

--- a/src/providers/TutorialHighlightingProvider/hooks/useReversedScrollY.ts
+++ b/src/providers/TutorialHighlightingProvider/hooks/useReversedScrollY.ts
@@ -1,8 +1,10 @@
+import { RefObject } from 'react';
+
 import { useScroll, useTransform } from 'framer-motion';
 
-export function useReversedScrollY() {
+export function useReversedScrollY(contentRef: RefObject<HTMLElement | null>) {
   const { scrollY } = useScroll({
-    container: { current: document.getElementById('content') },
+    container: contentRef,
   });
 
   return useTransform(scrollY, (value) => {


### PR DESCRIPTION


# Description

- This PR fixes a crash caused by bad usage of the "useScroll" hook from framer-motion in the tutorial highlight provider. The issue was that we in the current release just do "document.getElementById" to get the scrolling container (usually the Template.Content) div has this id. But since we wrap the whole app in this highlight provider, the div sometimes doesn't have time to render before the hook thus causing a crash


