### PR TITLE
:bug: Hide placeholder/values in Select components when loading=true

### DIFF
--- a/src/molecules/Select/Select.tsx
+++ b/src/molecules/Select/Select.tsx
@@ -193,7 +193,7 @@ export const Select = <T extends SelectOptionRequired>(
           $lightBackground={lightBackground}
         >
           <Section>
-            {search === '' && selectedValues.length === 0 && (
+            {!loading && search === '' && selectedValues.length === 0 && (
               <PlaceholderText>{placeholder}</PlaceholderText>
             )}
             {((search === '' && 'value' in props) ||
@@ -201,6 +201,7 @@ export const Select = <T extends SelectOptionRequired>(
                 selectedValues.length > 0 &&
                 (!props.showSelectedAsText ||
                   (props.showSelectedAsText && search === '')))) &&
+              !loading &&
               valueElements}
             <input
               id={id}


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#657447](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/657447)

---

- [ ] Needs to be tested locally by reviewer

# Description

- This PR hides the placeholder/value elements in the Select components when loading=true 
