### PR TITLE
:children_crossing: Add tooltips to impersonation user texts that might be truncated

### DIFF
--- a/src/organisms/TopBar/Account/ImpersonateMenu/UserImpersonation.tsx
+++ b/src/organisms/TopBar/Account/ImpersonateMenu/UserImpersonation.tsx
@@ -93,9 +93,13 @@ export const UserImpersonation: FC<UserImpersonationProps> = ({
           color={colors.text.static_icons__tertiary.rgba}
           data={account_circle}
         />
-        <Typography data-testid="name">{fullName}</Typography>
+        <OptionalTooltip title={fullName} placement="top">
+          <Typography data-testid="name">{fullName}</Typography>
+        </OptionalTooltip>
         <RoleChipContainer $selected={selected}>
-          <RoleChip data-testid="role">{activeRoles[0].label}</RoleChip>
+          <OptionalTooltip title={activeRoles.at(0)?.label} placement="top">
+            <RoleChip data-testid="role">{activeRoles[0].label}</RoleChip>
+          </OptionalTooltip>
           {activeRoles.length > 1 && (
             <OptionalTooltip
               title={activeRoles


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#656882](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/656882)

### Tasks
- [AB#657445](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/657445)

---

- [ ] Needs to be tested locally by reviewer

# Description

- This PR adds tooltips around truncated text in the impersonation menu
