### PR TITLE
:bug: Fix Button's internal disabled state not being false when loading is true

### DIFF
--- a/src/molecules/Button/Button.tsx
+++ b/src/molecules/Button/Button.tsx
@@ -42,12 +42,14 @@ const ButtonComponent = forwardRef<HTMLButtonElement, ButtonProps>(
         }
       : rest.style;
 
+    const usingDisabled = loading ? false : disabled;
+
     return (
       <BaseButton
         ref={ref}
         variant={variant}
         color={color}
-        disabled={disabled}
+        disabled={usingDisabled}
         onClick={loading ? undefined : onClick}
         {...rest}
         style={usingStyle}
@@ -63,7 +65,6 @@ const ButtonComponent = forwardRef<HTMLButtonElement, ButtonProps>(
                     variantAndColorToProgressColor({
                       variant,
                       color,
-                      disabled,
                     }) as CircularProgressProps['color']
                   }
                 />
@@ -72,7 +73,6 @@ const ButtonComponent = forwardRef<HTMLButtonElement, ButtonProps>(
                   color={variantAndColorToProgressColor({
                     variant,
                     color,
-                    disabled,
                   })}
                 />
               )}

--- a/src/molecules/Button/Button.utils.ts
+++ b/src/molecules/Button/Button.utils.ts
@@ -3,14 +3,11 @@ import { ButtonProps } from 'src/molecules/Button/Button';
 export function variantAndColorToProgressColor({
   variant,
   color,
-  disabled,
 }: {
   variant: ButtonProps['variant'] | undefined;
   color: ButtonProps['color'] | undefined;
-  disabled: boolean;
 }) {
   if (
-    disabled ||
     variant === undefined ||
     variant === 'contained' ||
     variant === 'contained_icon' ||


### PR DESCRIPTION
# Azure DevOps links

## User story
- AB#655818

---

- [ ] Needs to be tested locally by reviewer

# Description

- This PR fixes a bug where the buttons would not have disabled: false when loading is true. The onClick handler is already unset when loading is true


