### PR TITLE
:label: Fixed exports of const and types for IconCell colors, variants and states

### DIFF
--- a/src/molecules/index.ts
+++ b/src/molecules/index.ts
@@ -28,10 +28,16 @@ export { FullPageSpinner } from './FullPageSpinner/FullPageSpinner';
 export type { FullPageSpinnerProps } from './FullPageSpinner/FullPageSpinner';
 export { IconCell } from './IconCell/IconCell';
 export type { IconCellProps } from './IconCell/IconCell';
-export type {
+export {
   IconCellColors,
-  IconCellStates,
   IconCellVariants,
+  IconCellStates,
+} from './IconCell/IconCell.types';
+export type {
+  IconCellColor,
+  IconCellVariant,
+  IconCellState,
+  IconCellColorObject,
 } from './IconCell/IconCell.types';
 export { InfoElement } from './InfoElement/InfoElement';
 export type { InfoElementProps } from './InfoElement/InfoElement';


### PR DESCRIPTION
# Description

This PR fixes some exports necessary for the IconCell component. The colors, variants and states are handled through a constant, which is now exported together with the types.