### PR TITLE
fix/onremoved-image-rte

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@equinor/amplify-component-lib",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "description": "Frontend Typescript components for the Amplify team",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/molecules/RichTextEditor/EditorProvider.tsx
+++ b/src/molecules/RichTextEditor/EditorProvider.tsx
@@ -83,13 +83,11 @@ export const EditorProvider: FC<EditorProviderProps> = ({
         onImageRemove?.(image);
         deletedImages.current.push(image);
       }
-    }
-
-    if (
+    } else if (
       onRemovedImagesChange &&
       previousRemovedImages.current.length !== imagesToDelete.length
     ) {
-      onRemovedImagesChange(deletedImages.current);
+      onRemovedImagesChange(imagesToDelete);
       previousRemovedImages.current = imagesToDelete;
     }
   };


### PR DESCRIPTION
# Azure DevOps links

## User story
- [AB#677084](https://dev.azure.com/Equinor/1f7078da-0ba3-4461-a220-c3e39c5c1f09/_workitems/edit/677084)

---

- [ ] Needs to be tested locally by reviewer

# Description

- This PR fixes a bug with 'onRemovedImagesChange' not returning the correct array
